### PR TITLE
#27: wordseed component 구현

### DIFF
--- a/front/src/components/WordSeed/WordSeed.module.scss
+++ b/front/src/components/WordSeed/WordSeed.module.scss
@@ -1,0 +1,17 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 60px;
+  background-color: $light-gray;
+  border-radius: $radius-button;
+}
+
+.date {
+  @include font($fs: $body3, $fw: $regular, $fc: $gray, $ff: $noto-sans);
+}
+
+.wordSeed {
+  @include font($fs: $h3, $fw: $regular, $fc: $black, $ff: $noto-serif);
+}

--- a/front/src/components/WordSeed/WordSeed.tsx
+++ b/front/src/components/WordSeed/WordSeed.tsx
@@ -1,0 +1,14 @@
+import styles from "./WordSeed.module.scss";
+
+type WordSeedProps = {
+  date: string;
+  wordSeed: string;
+};
+export default function WordSeed({ date, wordSeed }: WordSeedProps) {
+  return (
+    <div className={styles.container}>
+      <p className={styles.date}>{date}</p>
+      <p className={styles.wordSeed}>{wordSeed}</p>
+    </div>
+  );
+}

--- a/front/src/components/index.ts
+++ b/front/src/components/index.ts
@@ -1,1 +1,2 @@
 export { default as Icon } from "./Icon/Icon";
+export { default as WordSeed } from "./WordSeed/WordSeed";


### PR DESCRIPTION
### WordSeed Props
```tsx
type WordSeedProps = {
  date: string;
  wordSeed: string;
};
````
- date
  - 말씨가 등록된 날짜
- wordSeed
  - 말씨


--- 

### WordSeed component
```tsx
import styles from "./WordSeed.module.scss";

type WordSeedProps = {
  date: string;
  wordSeed: string;
};
export default function WordSeed({ date, wordSeed }: WordSeedProps) {
  return (
    <div className={styles.container}>
      <p className={styles.date}>{date}</p>
      <p className={styles.wordSeed}>{wordSeed}</p>
    </div>
  );
}
```

