### PR TITLE
#27: WordSeed-Component 구현

### DIFF
--- a/front/src/app/wordlist/page.tsx
+++ b/front/src/app/wordlist/page.tsx
@@ -1,3 +1,12 @@
+import { WordSeed } from "@/components";
+
 export default function Wordlist() {
-  return <h1>Wordlist</h1>;
+  return (
+    <>
+      <h1>Wordlist</h1>
+      <WordSeed date="2024년 2월 9일" wordSeed="한 걸음" />
+      <WordSeed date="2024년 2월 9일" wordSeed="한 걸음" />
+      <WordSeed date="2024년 2월 9일" wordSeed="한 걸음" />
+    </>
+  );
 }

--- a/front/src/app/wordseed/[[...wordseed]]/page.tsx
+++ b/front/src/app/wordseed/[[...wordseed]]/page.tsx
@@ -1,5 +1,8 @@
 export default function Wordseed({ params }: { params: { wordseed: string } }) {
-  const wordseed = params.wordseed ? params.wordseed : "Today's Wordseed";
+  const wordseed = params.wordseed
+    ? decodeURIComponent(params.wordseed)
+    : "Today's Wordseed";
+
   return (
     <>
       <h1>Wordseed</h1>

--- a/front/src/components/WordSeed/WordSeed.module.scss
+++ b/front/src/components/WordSeed/WordSeed.module.scss
@@ -6,6 +6,13 @@
   height: 60px;
   background-color: $light-gray;
   border-radius: $radius-button;
+  background-color: white;
+  text-decoration: none;
+  margin-bottom: 0.9rem;
+
+  &:active {
+    background-color: $light-gray;
+  }
 }
 
 .date {

--- a/front/src/components/WordSeed/WordSeed.tsx
+++ b/front/src/components/WordSeed/WordSeed.tsx
@@ -1,12 +1,23 @@
+"use client";
+
 import styles from "./WordSeed.module.scss";
+import { useRouter } from "next/navigation";
 
 type WordSeedProps = {
   date: string;
   wordSeed: string;
 };
 export default function WordSeed({ date, wordSeed }: WordSeedProps) {
+  const router = useRouter();
+  const wordSeedLink = `/wordseed/${wordSeed}`;
+
   return (
-    <div className={styles.container}>
+    <div
+      onClick={() => {
+        router.push(wordSeedLink);
+      }}
+      className={styles.container}
+    >
       <p className={styles.date}>{date}</p>
       <p className={styles.wordSeed}>{wordSeed}</p>
     </div>


### PR DESCRIPTION
### WordSeed Props
```tsx
type WordSeedProps = {
  date: string;
  wordSeed: string;
};
````
- date
  - 말씨가 등록된 날짜
- wordSeed
  - 말씨


--- 

### WordSeed component
```tsx
"use client";

import styles from "./WordSeed.module.scss";
import { useRouter } from "next/navigation";

type WordSeedProps = {
  date: string;
  wordSeed: string;
};
export default function WordSeed({ date, wordSeed }: WordSeedProps) {
  const router = useRouter();
  const wordSeedLink = `/wordseed/${wordSeed}`;

  return (
    <div
      onClick={() => {
        router.push(wordSeedLink);
      }}
      className={styles.container}
    >
      <p className={styles.date}>{date}</p>
      <p className={styles.wordSeed}>{wordSeed}</p>
    </div>
  );
}
```
- 링크 기능
  - 카드를 클릭하면 해당 말씨 페이지로 이동 할 수 있도록 링크 지정
  - `next/Link`를 사용하는 경우 attr(커서를 올리면 링크가 보이는 기능/모바일에서는 롱터치 시 손가락 위치에 보임)이 생겨서 이를 없애고자 `useRouter`를 사용하여 링크기능을 구현