### PR TITLE
#22: WordSeedList Component 구현

### DIFF
--- a/front/src/app/wordlist/page.tsx
+++ b/front/src/app/wordlist/page.tsx
@@ -1,3 +1,64 @@
+import { WordSeedList } from "@/components";
+
+const datas: {
+  date: string;
+  wordSeed: string;
+}[] = [
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+  {
+    date: "2024년 2월 9일",
+    wordSeed: "한 걸음",
+  },
+];
+
 export default function Wordlist() {
-  return <h1>Wordlist</h1>;
+  return (
+    <>
+      <h1>Wordlist</h1>
+      <WordSeedList datas={datas} />
+    </>
+  );
 }

--- a/front/src/components/WordSeedList/WordSeedList.module.scss
+++ b/front/src/components/WordSeedList/WordSeedList.module.scss
@@ -1,0 +1,5 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  padding: 0 2rem;
+}

--- a/front/src/components/WordSeedList/WordSeedList.tsx
+++ b/front/src/components/WordSeedList/WordSeedList.tsx
@@ -1,0 +1,21 @@
+import { WordSeed } from "..";
+import styles from "./WordSeedList.module.scss";
+
+type WordSeedProps = {
+  date: string;
+  wordSeed: string;
+};
+
+type WordSeedListProps = {
+  datas: WordSeedProps[];
+};
+
+export default function WordSeedList({ datas }: WordSeedListProps) {
+  return (
+    <div className={styles.container}>
+      {datas.map((data) => (
+        <WordSeed key={data.date} date={data.date} wordSeed={data.wordSeed} />
+      ))}
+    </div>
+  );
+}

--- a/front/src/components/index.ts
+++ b/front/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as Icon } from "./Icon/Icon";
 export { default as WordSeed } from "./WordSeed/WordSeed";
+export { default as WordSeedList } from "./WordSeedList/WordSeedList";


### PR DESCRIPTION
### WordSeed Props
```tsx
type WordSeedProps = {
  date: string;
  wordSeed: string;
};

type WordSeedListProps = {
  datas: WordSeedProps[];
};
````
- date
  - 말씨가 등록된 날짜
- wordSeed
  - 말씨
- datas
  - WordSeedProp들의 배열

--- 

### WordSeed component
```tsx
import { WordSeed } from "..";
import styles from "./WordSeedList.module.scss";

type WordSeedProps = {
  date: string;
  wordSeed: string;
};

type WordSeedListProps = {
  datas: WordSeedProps[];
};

export default function WordSeedList({ datas }: WordSeedListProps) {
  return (
    <div className={styles.container}>
      {datas.map((data) => (
        <WordSeed key={data.date} date={data.date} wordSeed={data.wordSeed} />
      ))}
    </div>
  );
}
```
- 말씨와 날짜의 리스트인 datas를 받아서 `WordSeed`컴포넌트로 흩뿌려줌