### PR TITLE
#60: Content Card 컴포넌트 수정

### DIFF
--- a/front/src/components/ContentCard/ContentCard.module.scss
+++ b/front/src/components/ContentCard/ContentCard.module.scss
@@ -16,12 +16,19 @@
 .media {
   @include shadow-drop1();
   position: relative;
+  background-color: $light-gray;
 
   // 이미지 크기임시 값
-  height: 30rem;
+  min-height: 20rem;
 
   // z-index 는 임시
   z-index: -1;
+
+  video {
+    width: 100%;
+    height: 30rem;
+    object-fit: cover;
+  }
 }
 
 .wrapper {

--- a/front/src/components/ContentCard/ContentCard.tsx
+++ b/front/src/components/ContentCard/ContentCard.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import styles from "./ContentCard.module.scss";
 import Image from "next/image";
 import Link from "next/link";
+import { useRef, useState } from "react";
+import { useInView } from "react-intersection-observer";
 
 interface ContentCardProps {
   postId: number;
@@ -22,9 +26,21 @@ export default function ContentCard({
   url,
 }: ContentCardProps) {
   const contentClassName = `${styles.content} ${styles[textAlign]}`;
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [ref] = useInView({
+    threshold: 0.8,
+    onChange(inView) {
+      if (inView) {
+        videoRef?.current?.play();
+      } else {
+        videoRef?.current?.pause();
+      }
+    },
+    initialInView: true,
+  });
 
   return (
-    <Link className={styles.link} href={`/feed/${postId}`}>
+    <Link className={styles.link} href={`/feed/${postId}`} ref={ref}>
       {type === "text" ? (
         <main className={styles.container}>
           <div className={styles.wrapper}>
@@ -36,7 +52,17 @@ export default function ContentCard({
       ) : (
         <main className={styles.media}>
           {type === "img" && <Image src={url} alt="12" fill />}
-          {type === "video" && <iframe src={url} width={"100%"} />}
+          {type === "video" && (
+            <video
+              ref={videoRef}
+              muted
+              width={"100%"}
+              poster="placeholder.png"
+              preload={"none"}
+              playsInline
+              src={url}
+            ></video>
+          )}
           {type === "sound" && <audio src={url} controls />}
         </main>
       )}


### PR DESCRIPTION
```tsx
import { useInView } from "react-intersection-observer";

export default function ContentCard({
  postId,
  type,
  title,
  content,
  textAlign,
  userName,
  url,
}: ContentCardProps) {
  const contentClassName = `${styles.content} ${styles[textAlign]}`;
  const videoRef = useRef<HTMLVideoElement>(null);
  const [ref] = useInView({
    threshold: 0.8,
    onChange(inView) {
      if (inView) {
        videoRef?.current?.play();
      } else {
        videoRef?.current?.pause();
      }
    },
    initialInView: true,
  });

  return (
    <Link className={styles.link} href={`/feed/${postId}`} ref={ref}>
      {type === "text" ? (
        <main className={styles.container}>
          <div className={styles.wrapper}>
            <p className={styles.title}>{title}</p>
            <p className={contentClassName}>{content}</p>
            <p className={styles.artist}>{userName}</p>
          </div>
        </main>
      ) : (
        <main className={styles.media}>
          {type === "img" && <Image src={url} alt="12" fill />}
          {type === "video" && (
            <video
              ref={videoRef}
              muted
              width={"100%"}
              poster="placeholder.png"
              preload={"none"}
              playsInline
              src={url}
            ></video>
          )}
          {type === "sound" && <audio src={url} controls />}
        </main>
      )}
    </Link>
  );
}
```

- video에 videoRef를 video를 감싸는 wrapper에는 ref를 지정한다.
- `react-intersection-observer` 라이브러리의 useInView를 이용하여 ref가 화면에 80퍼 이상 보이거나 사라질 경우 videoRef.current의 재생 정지를 컨트롤할수 있게 지정하였다.