### PR TITLE
#57: button 컴포넌트 wide type 추가

### DIFF
--- a/front/src/app/profile/[user_id]/page.tsx
+++ b/front/src/app/profile/[user_id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useInView } from "react-intersection-observer";
 import useFilterButtonHiddenStateStore from "@/stores/profile-filter";
-import { ContentCardList } from "@/components";
+import { Button, ContentCardList } from "@/components";
 import Header from "../_component/Header";
 
 interface ContentCardProps {
@@ -78,6 +78,8 @@ export default function Profile({ params }: { params: { user_id: string } }) {
     <>
       <Header {...userData} />
       <h2>userId : {userId}</h2>
+      <Button type="wide" content="버튼" onClick={() => {}} />
+      <Button type="wide" content="활성화" onClick={() => {}} isActive />
       <div ref={ref}>Target</div>
       <ContentCardList datas={datas} />
       <div>page</div>

--- a/front/src/components/Button/Button.module.scss
+++ b/front/src/components/Button/Button.module.scss
@@ -15,3 +15,19 @@
     background-color: $gray;
   }
 }
+
+.button-wide {
+  @include font($fs: $body1, $fw: $regular, $fc: $gray, $ff: $noto-sans);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 33dvw;
+  height: 3rem;
+  background-color: $light-gray;
+  border-radius: $radius-button;
+
+  &.active {
+    color: $white;
+    background-color: $gray;
+  }
+}

--- a/front/src/components/Button/Button.tsx
+++ b/front/src/components/Button/Button.tsx
@@ -3,16 +3,26 @@
 import styles from "./Button.module.scss";
 
 type ButtonProps = {
+  type?: "default" | "wide";
   content: string | React.ReactNode;
   isActive?: boolean;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 };
-export default function Button({ content, isActive, onClick }: ButtonProps) {
+export default function Button({
+  type = "default",
+  content,
+  isActive,
+  onClick,
+}: ButtonProps) {
+  const defaultType = `${styles.button} ${isActive && styles.active} ${
+    typeof content === "string" && styles.text
+  }`;
+
+  const wideType = `${styles["button-wide"]} ${isActive && styles.active}`;
+
   return (
     <button
-      className={`${styles.button} ${isActive ? styles.active : ""} ${
-        typeof content === "string" ? styles.text : ""
-      }`}
+      className={type === "default" ? defaultType : wideType}
       onClick={onClick}
     >
       {content}

--- a/front/src/components/index.ts
+++ b/front/src/components/index.ts
@@ -6,9 +6,6 @@ export { default as ArtistCardList } from "./ArtistCardList/ArtistCardList";
 export { default as Button } from "./Button/Button";
 export { default as Navbar } from "./Navbar/Navbar";
 export { default as filter } from "./filter/filter";
-<<<<<<< HEAD
 export { default as ContentCard } from "./ContentCard/ContentCard";
 export { default as ContentCardList } from "./ContentCardList/ContentCardList";
-=======
 export { default as FeedInterface } from "./feed-interface/feed-interface";
->>>>>>> feat/#26-Feed-Interface-Component


### PR DESCRIPTION
```tsx
"use client";

import styles from "./Button.module.scss";

type ButtonProps = {
  type?: "default" | "wide";
  content: string | React.ReactNode;
  isActive?: boolean;
  onClick: React.MouseEventHandler<HTMLButtonElement>;
};
export default function Button({
  type = "default",
  content,
  isActive,
  onClick,
}: ButtonProps) {
  const defaultType = `${styles.button} ${isActive && styles.active} ${
    typeof content === "string" && styles.text
  }`;

  const wideType = `${styles["button-wide"]} ${isActive && styles.active}`;

  return (
    <button
      className={type === "default" ? defaultType : wideType}
      onClick={onClick}
    >
      {content}
    </button>
  );
}
```
- props에 `type` 속성을 추가하여 type에 따라 번튼 컴포넌트 클래스네임을 변경시켜서 적용함