### PR TITLE
#74: 유저 정보 조회 API

### DIFF
--- a/back/wordseed/src/main/java/com/spring/wordseed/WordseedApplication.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/WordseedApplication.java
@@ -2,7 +2,9 @@ package com.spring.wordseed;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class WordseedApplication {
 

--- a/back/wordseed/src/main/java/com/spring/wordseed/config/WebConfig.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.spring.wordseed.config;
+
+import com.spring.wordseed.interceptor.AuthInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final AuthInterceptor authInterceptor;
+
+    @Autowired
+    public WebConfig(AuthInterceptor authInterceptor) {
+        this.authInterceptor = authInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/user/**");
+    }
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/AccountController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/AccountController.java
@@ -1,4 +1,27 @@
 package com.spring.wordseed.controller;
 
+import com.spring.wordseed.dto.in.CreateUserInDTO;
+import com.spring.wordseed.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/account", produces = "application/json; charset=utf-8")
 public class AccountController {
+    private final UserService userService;
+
+    @Autowired
+    public AccountController(UserService userService) {
+        this.userService = userService;
+    }
+    @PostMapping
+    public ResponseEntity<Long> createUser(@RequestBody CreateUserInDTO createUserInDTO) throws Exception{
+        long userId = userService.createUser(createUserInDTO);
+        return ResponseEntity.status(HttpStatus.OK).body(userId);
+    }
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/UserController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/UserController.java
@@ -8,6 +8,9 @@ import com.spring.wordseed.dto.tool.UserDTO;
 import com.spring.wordseed.enu.FollowType;
 import com.spring.wordseed.enu.Informable;
 import com.spring.wordseed.enu.UserType;
+import com.spring.wordseed.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,16 +22,16 @@ import java.util.List;
 @RestController
 @RequestMapping(value = "/user", produces = "application/json; charset=utf-8")
 public class UserController {
+    private final UserService userService;
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
     @GetMapping
-    public ResponseEntity<ReadUserOutDTO> readUser() throws Exception {
-        ReadUserOutDTO readUserOutDTO = ReadUserOutDTO.builder()
-                .userId(1)
-                .userName("초아누리")
-                .userType(UserType.USER)
-                .email("cho0123@wordseed.com")
-                .userDecp("모든 순간을 사랑하며 살고 싶은 사람")
-                .informable(Informable.TRUE)
-                .build();
+    public ResponseEntity<ReadUserOutDTO> readUser(HttpServletRequest request) throws Exception {
+        long userId = (long) request.getAttribute("userId");
+        ReadUserOutDTO readUserOutDTO = userService.readUser(userId);
         return ResponseEntity.status(HttpStatus.OK).body(readUserOutDTO);
     }
     @PutMapping

--- a/back/wordseed/src/main/java/com/spring/wordseed/dto/in/CreateUserInDTO.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/dto/in/CreateUserInDTO.java
@@ -1,0 +1,14 @@
+package com.spring.wordseed.dto.in;
+
+import com.spring.wordseed.enu.UserType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateUserInDTO {
+    String userName;
+    String email;
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/dto/out/ReadUserOutDTO.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/dto/out/ReadUserOutDTO.java
@@ -2,29 +2,18 @@ package com.spring.wordseed.dto.out;
 
 import com.spring.wordseed.enu.Informable;
 import com.spring.wordseed.enu.UserType;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class ReadUserOutDTO {
-    long userId;
-    String userName;
-    UserType userType;
-    String email;
-    String userDecp;
-    Informable informable;
-
-    @Builder
-    public ReadUserOutDTO(long userId, String userName, UserType userType, String email, String userDecp, Informable informable) {
-        this.userId = userId;
-        this.userName = userName;
-        this.userType = userType;
-        this.email = email;
-        this.userDecp = userDecp;
-        this.informable = informable;
-    }
+    private long userId;
+    private String userName;
+    private UserType userType;
+    private String email;
+    private String userDecp;
+    private Informable informable;
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/entity/BaseTimeEntity.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/entity/BaseTimeEntity.java
@@ -5,11 +5,12 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @MappedSuperclass
-@EntityListeners(AutoCloseable.class)
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
     @CreatedDate
     @Column(nullable = false)

--- a/back/wordseed/src/main/java/com/spring/wordseed/entity/User.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/entity/User.java
@@ -2,9 +2,7 @@ package com.spring.wordseed.entity;
 
 import com.spring.wordseed.enu.UserType;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.ArrayList;
@@ -13,7 +11,9 @@ import java.util.List;
 @Entity
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "users")
 public class User extends BaseTimeEntity {

--- a/back/wordseed/src/main/java/com/spring/wordseed/entity/UserInfo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/entity/UserInfo.java
@@ -2,22 +2,23 @@ package com.spring.wordseed.entity;
 
 import com.spring.wordseed.enu.Informable;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "user_infos")
 public class UserInfo extends BaseTimeEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userInfoId;
-    private String userDesc;
+    private String userDecp;
     @Column(nullable = false)
     private Long postCnt;
     @Column(nullable = false)

--- a/back/wordseed/src/main/java/com/spring/wordseed/exception/GlobalExceptionHandler.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.spring.wordseed.exception;
+
+import jakarta.security.auth.message.AuthException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(value = {Exception.class})
+    public ResponseEntity<String> handleException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Server Error");
+    }
+    @ExceptionHandler(value = {IllegalArgumentException.class})
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Bad Request");
+    }
+    @ExceptionHandler(value = {AuthException.class})
+    public ResponseEntity<String> handleAuthException(AuthException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+    }
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/interceptor/AuthInterceptor.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/interceptor/AuthInterceptor.java
@@ -1,0 +1,32 @@
+package com.spring.wordseed.interceptor;
+
+import jakarta.security.auth.message.AuthException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+    @Value("${auth.header}")
+    private String AUTHORIZATION_HEADER;
+    @Value("${auth.prefix}")
+    private String AUTHORIZATION_PREFIX;
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if(request.getMethod().equals("OPTIONS")) return true;
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+        if(authorizationHeader == null || !authorizationHeader.startsWith(AUTHORIZATION_PREFIX + " ")) {
+            throw new AuthException();
+        }
+        try {
+            String token = authorizationHeader.substring(AUTHORIZATION_PREFIX.length() + 1);
+            long userId = Long.parseLong(token);
+            request.setAttribute("userId", userId);
+        }catch (NumberFormatException e) {
+            throw new AuthException();
+        }
+        return HandlerInterceptor.super.preHandle(request, response, handler);
+    }
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/UserInfoRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/UserInfoRepo.java
@@ -1,0 +1,10 @@
+package com.spring.wordseed.repo;
+
+import com.spring.wordseed.entity.UserInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserInfoRepo extends JpaRepository<UserInfo, Long> {
+
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/UserRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/UserRepo.java
@@ -1,0 +1,10 @@
+package com.spring.wordseed.repo;
+
+import com.spring.wordseed.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepo extends JpaRepository<User, Long> {
+
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/UserService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/UserService.java
@@ -1,0 +1,11 @@
+package com.spring.wordseed.service;
+
+import com.spring.wordseed.dto.in.CreateUserInDTO;
+import com.spring.wordseed.dto.out.ReadUserOutDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface UserService {
+    long createUser(CreateUserInDTO createUserInDTO) throws Exception;
+    ReadUserOutDTO readUser(long userId) throws Exception;
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
@@ -35,7 +35,6 @@ public class UserServiceImpl implements UserService {
                     .userDecp("")
                     .build();
             userInfo = userInfoRepo.save(userInfo);
-            System.out.println(userInfo.getUserInfoId());
             User user = User.builder()
                     .userName(createUserInDTO.getUserName())
                     .email(createUserInDTO.getEmail())

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
@@ -1,0 +1,64 @@
+package com.spring.wordseed.service.impl;
+
+import com.spring.wordseed.dto.in.CreateUserInDTO;
+import com.spring.wordseed.dto.out.ReadUserOutDTO;
+import com.spring.wordseed.entity.User;
+import com.spring.wordseed.entity.UserInfo;
+import com.spring.wordseed.enu.Informable;
+import com.spring.wordseed.enu.UserType;
+import com.spring.wordseed.repo.UserInfoRepo;
+import com.spring.wordseed.repo.UserRepo;
+import com.spring.wordseed.service.UserService;
+import jakarta.security.auth.message.AuthException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class UserServiceImpl implements UserService {
+    private final UserRepo userRepo;
+    private final UserInfoRepo userInfoRepo;
+    @Autowired
+    public UserServiceImpl(UserRepo userRepo, UserInfoRepo userInfoRepo) {
+        this.userRepo = userRepo;
+        this.userInfoRepo = userInfoRepo;
+    }
+    @Override
+    public long createUser(CreateUserInDTO createUserInDTO) throws Exception{
+        try {
+            UserInfo userInfo = UserInfo.builder()
+                    .followDstCnt(0L)
+                    .followSrcCnt(0L)
+                    .postCnt(0L)
+                    .informable(Informable.FALSE)
+                    .userDecp("")
+                    .build();
+            userInfo = userInfoRepo.save(userInfo);
+            System.out.println(userInfo.getUserInfoId());
+            User user = User.builder()
+                    .userName(createUserInDTO.getUserName())
+                    .email(createUserInDTO.getEmail())
+                    .userInfo(userInfo)
+                    .userType(UserType.USER)
+                    .build();
+            user = userRepo.save(user);
+            return user.getUserId();
+        }catch (Exception e) {
+            throw new IllegalArgumentException();
+        }
+    }
+    @Override
+    public ReadUserOutDTO readUser(long userId) throws Exception {
+        User user = userRepo.findById(userId)
+                    .orElseThrow(IllegalArgumentException::new);
+        return ReadUserOutDTO.builder()
+                .userId(user.getUserId())
+                .userName(user.getUserName())
+                .userType(user.getUserType())
+                .userDecp(user.getUserInfo().getUserDecp())
+                .email(user.getEmail())
+                .informable(user.getUserInfo().getInformable())
+                .build();
+    }
+}


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- 유저 정보 조회 API 구현
- 데이터 삽입 편의성을 위해 임의로 유저 정보 등록 API구현
- Header에서 userId 추출 로직을 사용하기 위해 Interceptor 구현
- 에러 발생 시 Client에 에러 코드를 반환하는 ExceptionHandler 구현

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### Feat: 추가 - 유저 정보 등록/조회 API - cca3fe12f8f7936c172590b6ef5a56869e09b6d9
#### 유저 조회(GET /user)- readUser()
- Reqeust Attribute에서 추출한 userId로 UserService에서 user를 찾아 반환 (엔티티가 null인 경우 IllegalArgumentException)
#### 유저 등록(POST /account) - createUser()
- UserInfo를 생성 및 등록
- User에 UserInfo를 넣어 연관 관계를 함께 등록 (중복 이메일 등, 에러 발생 시 IllegalArgumentException)
- 등록 성공 시 userId를 반환
#### AuthInterceptor
- 헤더로 넘어온 userId를 추출 -> Request Attribute에 저장 (헤더 이름이나 값에 이상이 있을 시 AuthException)
- 원래는 토큰을 사용해야 하나 임의로 userId를 그대로 사용하였습니다.
- WebConfig에 인터셉터 등록 (현재는 /user/** 패턴에만 적용)
#### GlobalExceptionHandler
- API에서 에러 발생 시 Client에게 에러 코드를 반환하도록 설정
- AuthException -> Unauthorized
- IllegalArgumentException -> Bad Request
#### @EnableJpaAuditing 추가
- @CreatedDate, @LastModifiedDate 사용을 위해 BaseTimeEntity에 AuditingEntityListener로 리스너 변경
- WordseedApplication에 @EnableJpaAuditing를 추가해서 적용
#### env.properties에 헤더에 사용할 Value 추가
- AUTHORIZATION_HEADER
- AUTHORIZATION_PREFIX
## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->
- [X] localhost에서 PostMan으로 등록/조회 확인
- [X] 에러 발생 시 Client에 에러 반환 확인

## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->
- DB에 유저를 직접 등록하는 게 비효율적이라 생각해서 임의로 API를 구현하였습니다.
- 엔티티 등록 시 default value를 직접 개발자가 Builder로 넣는 방법을 사용하였습니다.
- Interceptor를 현재는 /user/** 패턴에만 적용하였습니다.
- 다음부터는 먼저 구현이 필요한 부분을 미리 구현하고 커밋하여 커밋을 쪼갤 수 있도록 하겠습니다.


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
- 유저 등록 Request Body 예시
![image](https://github.com/Project-0123/0123/assets/33569961/08cec44d-045d-4b2a-9b7e-2b824658ef32)

