### PR TITLE
#87: PostService 중 readPostByPostId 메서드 구현

### DIFF
--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
@@ -39,8 +39,6 @@ public class PostController {
                                                           @RequestParam("size") Long size) throws Exception {
         ReadPostOutDTOs readPostOutDTOs = postService.readPosts(postType, mark, userId, sort, query, page, size);
 
-
-
         return ResponseEntity.status(HttpStatus.OK).body(readPostOutDTOs);
     }
     // 작품 상세 조회

--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
@@ -46,27 +46,7 @@ public class PostController {
     // 작품 상세 조회
     @GetMapping("/detail")
     public ResponseEntity<ReadPostByPostIdOutDTO> readPostByPostId(@RequestParam("postId") Long postId) throws Exception {
-        ReadPostByPostIdOutDTO readPostByPostIdOutDTO = ReadPostByPostIdOutDTO.builder()
-                .postId(1L)
-                .userId(1L)
-                .userName("userName")
-                .postType(PostType.TEXT)
-                .postAlign(PostAlign.LEFT)
-                .postVisibility(PostVisibility.PRIVATE)
-                .content("content")
-                .url("url")
-                .likedCnt(0L)
-                .bookMarkCnt(0L)
-                .commentCnt(0L)
-                .liked(true)
-                .bookMarked(true)
-                .subscribed(true)
-                .wordId(1L)
-                .word("word")
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
-
+        ReadPostByPostIdOutDTO readPostByPostIdOutDTO = postService.readPostByPostId(postId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTO);
     }
     // 작품 수정

--- a/back/wordseed/src/main/java/com/spring/wordseed/dto/out/ReadPostByPostIdOutDTO.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/dto/out/ReadPostByPostIdOutDTO.java
@@ -3,14 +3,14 @@ package com.spring.wordseed.dto.out;
 import com.spring.wordseed.enu.PostAlign;
 import com.spring.wordseed.enu.PostType;
 import com.spring.wordseed.enu.PostVisibility;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Setter
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class ReadPostByPostIdOutDTO {
     private Long postId;

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/PostRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/PostRepo.java
@@ -1,6 +1,7 @@
 package com.spring.wordseed.repo;
 
 import com.spring.wordseed.entity.Post;
+import com.spring.wordseed.repo.custom.CustomPostRepo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,6 +9,6 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PostRepo extends JpaRepository<Post, Long> {
+public interface PostRepo extends JpaRepository<Post, Long>, CustomPostRepo {
 
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomPostRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomPostRepo.java
@@ -1,0 +1,13 @@
+package com.spring.wordseed.repo.custom;
+
+import com.spring.wordseed.dto.out.ReadPostByPostIdOutDTO;
+import com.spring.wordseed.dto.out.ReadPostOutDTO;
+import com.spring.wordseed.entity.Post;
+import com.spring.wordseed.enu.PostSort;
+import com.spring.wordseed.enu.PostType;
+
+import java.util.List;
+
+public interface CustomPostRepo {
+    ReadPostByPostIdOutDTO findPostByPostId(Long postId);
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/repo/CustomPostRepoImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/repo/CustomPostRepoImpl.java
@@ -1,0 +1,95 @@
+package com.spring.wordseed.repo.custom.impl;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.spring.wordseed.dto.out.ReadPostByPostIdOutDTO;
+import com.spring.wordseed.dto.out.ReadPostOutDTO;
+import com.spring.wordseed.entity.*;
+import com.spring.wordseed.enu.PostSort;
+import com.spring.wordseed.enu.PostType;
+import com.spring.wordseed.repo.custom.CustomPostRepo;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import org.hibernate.query.criteria.JpaSubQuery;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class CustomPostRepoImpl implements CustomPostRepo {
+    @PersistenceContext
+    EntityManager em;
+    private final QPost qPost = QPost.post;
+    private final QUser qUser = QUser.user;
+    private final QUser qUser2 = new QUser("user2");
+    private final QBookMark qBookMark = QBookMark.bookMark;
+    private final QPostLiked qPostLiked = QPostLiked.postLiked;
+    private final QWord qWord = QWord.word1;
+    private final QFollow qFollow = QFollow.follow;
+
+    @Override
+    public ReadPostByPostIdOutDTO findPostByPostId(Long postId) {
+        BooleanExpression likedExpression = JPAExpressions
+                .selectOne()
+                .from(qPost)
+                .join(qPost.postLikeds, qPostLiked)
+                .where(qPostLiked.user.userId.eq(7L))
+                .where(qPost.postId.eq(postId))
+                .exists();
+
+        BooleanExpression bookMarkedExpression = JPAExpressions
+                .selectOne()
+                .from(qPost)
+                .join(qPost.bookMarks, qBookMark)
+                .where(qBookMark.user.userId.eq(7L))
+                .where(qPost.postId.eq(postId))
+                .exists();
+
+        BooleanExpression subscribedExpression = JPAExpressions
+                .selectOne()
+                .from(qFollow)
+                .join(qFollow.srcUser, qUser)
+                .join(qFollow.dstUser, qUser2)
+                .join(qUser2.posts, qPost)
+                .where(qUser.userId.eq(7L))
+                .where(qPost.postId.eq(postId))
+                .exists();
+
+        ReadPostByPostIdOutDTO readPostByPostIdOutDTO = new JPAQuery<>(em)
+                .select(Projections.constructor(
+                        ReadPostByPostIdOutDTO.class,
+                        qPost.postId.as("postId"),
+                        qPost.user.userId.as("userId"),
+                        qPost.user.userName.as("userName"),
+                        qPost.postType.as("postType"),
+                        qPost.postAlign.as("postAlign"),
+                        qPost.postVisibility.as("postVisibility"),
+                        qPost.content.as("content"),
+                        qPost.url.as("url"),
+                        qPost.likedCnt.as("likedCnt"),
+                        qPost.bookMarkCnt.as("bookMarkCnt"),
+                        qPost.commentCnt.as("commentCnt"),
+                        likedExpression.as("liked"),
+                        bookMarkedExpression.as("bookMarked"),
+                        subscribedExpression.as("subscribed"),
+                        qWord.wordId.as("wordId"),
+                        qWord.word.as("word"),
+                        qPost.createdAt.as("createdAt"),
+                        qPost.updatedAt.as("updatedAt")))
+                .from(qPost)
+                .join(qPost.user, qUser)
+                .join(qPost.word, qWord)
+                .where(qPost.postId.eq(postId))
+                .fetchOne();
+
+        return readPostByPostIdOutDTO;
+    }
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
@@ -78,7 +78,8 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public ReadPostByPostIdOutDTO readPostByPostId(Long postId) {
-        return null;
+        //
+
     }
 
     @Override

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
@@ -7,6 +7,7 @@ import com.spring.wordseed.enu.PostSort;
 import com.spring.wordseed.repo.PostRepo;
 import com.spring.wordseed.repo.UserRepo;
 import com.spring.wordseed.repo.WordRepo;
+import com.spring.wordseed.repo.custom.CustomPostRepo;
 import com.spring.wordseed.service.PostService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.crossstore.ChangeSetPersister;
@@ -78,8 +79,8 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public ReadPostByPostIdOutDTO readPostByPostId(Long postId) {
-        //
-
+        ReadPostByPostIdOutDTO readPostByPostIdOutDTO = postRepo.findPostByPostId(postId);
+        return readPostByPostIdOutDTO;
     }
 
     @Override


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- PostService 중 readPostByPostId 메서드 구현

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
#### PostService 중 readPostByPostId 메서드 구현 - 1e3d5810f08fb18da7265e39cfe15a7934d770b6
- QueryDSL을 이용하여 readPostByPostId 구현

## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->
- [X] postMan을 이용하여 readPostByPostId 작동 여부 테스트 진행 

## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->
- readPostByPostId중 liked, bookmarked, subscribed에 대한 쿼리 효율성 논의
- userId가 7로 하드코딩 되어있음. 수정 필요

## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
