### PR TITLE
#81: 유저 정보 수정 API 구현 

### DIFF
--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/UserController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/UserController.java
@@ -15,7 +15,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,17 +34,11 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(readUserOutDTO);
     }
     @PutMapping
-    public ResponseEntity<UpdateUserOutDTO> updateUser(@RequestBody UpdateUserInDTO updateUserInDTO) throws Exception {
-        UpdateUserOutDTO updateUserOutDTO = UpdateUserOutDTO.builder()
-                .userId(1)
-                .userName(updateUserInDTO.getUserName())
-                .userType(updateUserInDTO.getUserType())
-                .email("cho0123@wordseed.com")
-                .userDecp(updateUserInDTO.getUserDecp())
-                .informable(updateUserInDTO.getInformable())
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
-                .build();
+    public ResponseEntity<UpdateUserOutDTO> updateUser(@RequestBody UpdateUserInDTO updateUserInDTO,
+                                                       HttpServletRequest request) throws Exception {
+        long userId = (long) request.getAttribute("userId");
+        updateUserInDTO.setUserId(userId);
+        UpdateUserOutDTO updateUserOutDTO = userService.updateUser(updateUserInDTO);
         return ResponseEntity.status(HttpStatus.OK).body(updateUserOutDTO);
     }
     @DeleteMapping

--- a/back/wordseed/src/main/java/com/spring/wordseed/dto/in/UpdateUserInDTO.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/dto/in/UpdateUserInDTO.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class UpdateUserInDTO {
+    long userId;
     String userName;
     UserType userType;
     String userDecp;

--- a/back/wordseed/src/main/java/com/spring/wordseed/entity/User.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/entity/User.java
@@ -30,7 +30,7 @@ public class User extends BaseTimeEntity {
     private String deviceToken;
     private String refreshToken;
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    @JoinColumn(name = "user_info_id")
+    @JoinColumn(name = "user_info_id", nullable = false)
     private UserInfo userInfo;
     @Builder.Default
     @OneToMany(mappedBy = "srcUser", fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/back/wordseed/src/main/java/com/spring/wordseed/exception/GlobalExceptionHandler.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.spring.wordseed.exception;
 import jakarta.security.auth.message.AuthException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,6 +15,10 @@ public class GlobalExceptionHandler {
     }
     @ExceptionHandler(value = {IllegalArgumentException.class})
     public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Bad Request");
+    }
+    @ExceptionHandler(value = {HttpMessageNotReadableException.class})
+    public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Bad Request");
     }
     @ExceptionHandler(value = {AuthException.class})

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/UserRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/UserRepo.java
@@ -1,10 +1,11 @@
 package com.spring.wordseed.repo;
 
 import com.spring.wordseed.entity.User;
+import com.spring.wordseed.repo.custom.CustomUserRepo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserRepo extends JpaRepository<User, Long> {
+public interface UserRepo extends JpaRepository<User, Long>, CustomUserRepo {
 
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomUserRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomUserRepo.java
@@ -1,0 +1,9 @@
+package com.spring.wordseed.repo.custom;
+
+import com.spring.wordseed.entity.User;
+
+import java.util.Optional;
+
+public interface CustomUserRepo {
+    Optional<User> findWithUserInfoById(long userId) throws Exception;
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomUserRepoImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomUserRepoImpl.java
@@ -1,0 +1,29 @@
+package com.spring.wordseed.repo.custom.impl;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.spring.wordseed.entity.QUser;
+import com.spring.wordseed.entity.QUserInfo;
+import com.spring.wordseed.entity.User;
+import com.spring.wordseed.repo.custom.CustomUserRepo;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import java.util.Optional;
+
+public class CustomUserRepoImpl implements CustomUserRepo {
+    @PersistenceContext
+    EntityManager em;
+    private final QUser qUser = QUser.user;
+    private final QUserInfo qUserInfo = QUserInfo.userInfo;
+
+    @Override
+    public Optional<User> findWithUserInfoById(long userId) throws Exception {
+        User user = new JPAQuery<>(em)
+                .select(qUser)
+                .from(qUser)
+                .join(qUser.userInfo, qUserInfo).fetchJoin()
+                .where(qUser.userId.eq(userId))
+                .fetchOne();
+        return Optional.ofNullable(user);
+    }
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/UserService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/UserService.java
@@ -1,11 +1,14 @@
 package com.spring.wordseed.service;
 
 import com.spring.wordseed.dto.in.CreateUserInDTO;
+import com.spring.wordseed.dto.in.UpdateUserInDTO;
 import com.spring.wordseed.dto.out.ReadUserOutDTO;
+import com.spring.wordseed.dto.out.UpdateUserOutDTO;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface UserService {
     long createUser(CreateUserInDTO createUserInDTO) throws Exception;
     ReadUserOutDTO readUser(long userId) throws Exception;
+    UpdateUserOutDTO updateUser(UpdateUserInDTO updateUserInDTO) throws Exception;
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
@@ -1,7 +1,9 @@
 package com.spring.wordseed.service.impl;
 
 import com.spring.wordseed.dto.in.CreateUserInDTO;
+import com.spring.wordseed.dto.in.UpdateUserInDTO;
 import com.spring.wordseed.dto.out.ReadUserOutDTO;
+import com.spring.wordseed.dto.out.UpdateUserOutDTO;
 import com.spring.wordseed.entity.User;
 import com.spring.wordseed.entity.UserInfo;
 import com.spring.wordseed.enu.Informable;
@@ -9,7 +11,6 @@ import com.spring.wordseed.enu.UserType;
 import com.spring.wordseed.repo.UserInfoRepo;
 import com.spring.wordseed.repo.UserRepo;
 import com.spring.wordseed.service.UserService;
-import jakarta.security.auth.message.AuthException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,6 +59,27 @@ public class UserServiceImpl implements UserService {
                 .userDecp(user.getUserInfo().getUserDecp())
                 .email(user.getEmail())
                 .informable(user.getUserInfo().getInformable())
+                .build();
+    }
+
+    @Override
+    public UpdateUserOutDTO updateUser(UpdateUserInDTO updateUserInDTO) throws Exception {
+        User user = userRepo.findWithUserInfoById(updateUserInDTO.getUserId())
+                .orElseThrow(IllegalArgumentException::new);
+        if(updateUserInDTO.getUserName() == null) throw new IllegalArgumentException();
+        user.setUserName(updateUserInDTO.getUserName());
+        user.setUserType(updateUserInDTO.getUserType());
+        user.getUserInfo().setUserDecp(updateUserInDTO.getUserDecp());
+        user.getUserInfo().setInformable(updateUserInDTO.getInformable());
+        return UpdateUserOutDTO.builder()
+                .userId(user.getUserId())
+                .userName(user.getUserName())
+                .userType(user.getUserType())
+                .email(user.getEmail())
+                .userDecp(user.getUserInfo().getUserDecp())
+                .informable(user.getUserInfo().getInformable())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- 유저 정보 수정 부분 CustomRepo를 사용해서 구현
- 새로운 Exception Handler 추가
## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### Feat: 추가 - 유저 정보 수정 API - 774739079d42626782db29b08854785c4b2f6b30
- UpdateUserInDTO에 userId를 추가해서 service에 한번에 보내도록 수정
- CustomUserRepo를 만들어 UserRepo가 상속 받는 방식 사용
- User와 UserInfo 둘 다 수정해야 하기 때문에 페치 조인으로 쿼리 한 번으로 두 엔티티를 모두 불러오도록 구현
- userName이 null인 경우, IllegalArgumentException를 던져서 Server error 대신 Bad Request로 응답
### Feat: 추가 - HttpMessageNotReadableException Handler 추가 - c56d8a40bc877b667b0a7186c9bd038f31b70a30
- Request를 받을 때, Enum Type이 없거나 값이 이상할 경우, HttpMessageNotReadableException이 발생
- Exception Handler를 사용해서 Server Error를 Bad Request로 응답하도록 수정
## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->
- 테스트 환경: localhost, PostMan으로 API 호출
- [X] userName, userType, userDecp, informable 수정 후 응답 확인
- [X] enum type에서 에러 발생 또는 userName이 null일 경우, Bad Request로 응답 확인
 
## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->
- createdAt, updatedAt이 UTC 기준으로 적용 되는데 H2 설정을 따로 안 해줘서 그런 것 같습니다.
- 나중에 실제 서버에 올렸을 때도 차이가 있을 수 있으니, 후에 일괄 수정해야 할 것 같습니다.

## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
- Request Body 예시
![image](https://github.com/Project-0123/0123/assets/33569961/eadf72ae-b2bd-433c-b565-706898c3e121)
