### PR TITLE
#119 말씨 등록/조회

### DIFF
--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/WordController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/WordController.java
@@ -32,11 +32,7 @@ public class WordController {
     }
     @GetMapping
     public ResponseEntity<ReadWordByDateOutDTO> readWordByDate(@RequestParam("date") @DateTimeFormat(pattern="yyyy-mm-dd") LocalDate date) throws Exception {
-        ReadWordByDateOutDTO readWordByDateOutDTO = ReadWordByDateOutDTO.builder()
-                .wordId(1)
-                .date(date)
-                .word("하늘")
-                .build();
+        ReadWordByDateOutDTO readWordByDateOutDTO = wordService.readWordByDate(date);
         return ResponseEntity.status(HttpStatus.OK).body(readWordByDateOutDTO);
     }
 

--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/WordController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/WordController.java
@@ -1,6 +1,7 @@
 package com.spring.wordseed.controller;
 
 import com.spring.wordseed.dto.in.CreateWordInDTO;
+import com.spring.wordseed.dto.in.ReadWordInDTOs;
 import com.spring.wordseed.dto.out.ReadWordByDateOutDTO;
 import com.spring.wordseed.dto.out.ReadWordOutDTOs;
 import com.spring.wordseed.dto.tool.WordDTO;
@@ -37,19 +38,8 @@ public class WordController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<ReadWordOutDTOs> readWords(@RequestParam("query") String query,
-                                                     @RequestParam("page") long page,
-                                                     @RequestParam("size") long size) throws Exception {
-        List<WordDTO> words = new ArrayList<>();
-        for(int i=1;i<=size;i++) {
-            WordDTO word = WordDTO.builder()
-                    .wordId(i)
-                    .word("" + query + page + i)
-                    .createdAt(LocalDate.now().plusDays(i))
-                    .build();
-            words.add(word);
-        }
-        ReadWordOutDTOs readWordOutDTOs = new ReadWordOutDTOs(words);
+    public ResponseEntity<ReadWordOutDTOs> readWords(@ModelAttribute ReadWordInDTOs readWordInDTOs) throws Exception {
+        ReadWordOutDTOs readWordOutDTOs = wordService.readWords(readWordInDTOs);
         return ResponseEntity.status(HttpStatus.OK).body(readWordOutDTOs);
     }
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/WordController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/WordController.java
@@ -1,15 +1,15 @@
 package com.spring.wordseed.controller;
 
+import com.spring.wordseed.dto.in.CreateWordInDTO;
 import com.spring.wordseed.dto.out.ReadWordByDateOutDTO;
 import com.spring.wordseed.dto.out.ReadWordOutDTOs;
 import com.spring.wordseed.dto.tool.WordDTO;
+import com.spring.wordseed.service.WordService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -18,6 +18,18 @@ import java.util.List;
 @RestController
 @RequestMapping(value = "/word", produces = "application/json; charset=utf-8")
 public class WordController {
+    private final WordService wordService;
+
+    @Autowired
+    public WordController(WordService wordService) {
+        this.wordService = wordService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Long> createWord(@RequestBody CreateWordInDTO createWordInDTO) throws Exception {
+        long wordId = wordService.createWord(createWordInDTO);
+        return ResponseEntity.status(HttpStatus.OK).body(wordId);
+    }
     @GetMapping
     public ResponseEntity<ReadWordByDateOutDTO> readWordByDate(@RequestParam("date") @DateTimeFormat(pattern="yyyy-mm-dd") LocalDate date) throws Exception {
         ReadWordByDateOutDTO readWordByDateOutDTO = ReadWordByDateOutDTO.builder()

--- a/back/wordseed/src/main/java/com/spring/wordseed/dto/in/CreateWordInDTO.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/dto/in/CreateWordInDTO.java
@@ -1,0 +1,16 @@
+package com.spring.wordseed.dto.in;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class CreateWordInDTO {
+    String word;
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    LocalDate date;
+
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/dto/in/ReadWordInDTOs.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/dto/in/ReadWordInDTOs.java
@@ -1,0 +1,14 @@
+package com.spring.wordseed.dto.in;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadWordInDTOs {
+    String query;
+    long page;
+    long size;
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/entity/Word.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/entity/Word.java
@@ -22,7 +22,7 @@ public class Word extends BaseTimeEntity{
     private Long wordId;
     @Column(nullable = false)
     private String word;
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private LocalDate date;
     @Builder.Default
     @OneToMany(mappedBy = "word", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/WordRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/WordRepo.java
@@ -4,9 +4,11 @@ import com.spring.wordseed.entity.Word;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Repository
 public interface WordRepo extends JpaRepository<Word, Long> {
     Optional<Word> findById(Long wordId);
+    Optional<Word> findFirstByDate(LocalDate date);
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/WordRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/WordRepo.java
@@ -1,14 +1,17 @@
 package com.spring.wordseed.repo;
 
 import com.spring.wordseed.entity.Word;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface WordRepo extends JpaRepository<Word, Long> {
     Optional<Word> findById(Long wordId);
     Optional<Word> findFirstByDate(LocalDate date);
+    Optional<List<Word>> findByWordStartsWith(String word, PageRequest pageRequest);
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/WordService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/WordService.java
@@ -1,9 +1,13 @@
 package com.spring.wordseed.service;
 
 import com.spring.wordseed.dto.in.CreateWordInDTO;
+import com.spring.wordseed.dto.out.ReadWordByDateOutDTO;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 
 @Service
 public interface WordService {
     long createWord(CreateWordInDTO createWordInDTO) throws Exception;
+    ReadWordByDateOutDTO readWordByDate(LocalDate date) throws Exception;
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/WordService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/WordService.java
@@ -1,0 +1,9 @@
+package com.spring.wordseed.service;
+
+import com.spring.wordseed.dto.in.CreateWordInDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface WordService {
+    long createWord(CreateWordInDTO createWordInDTO) throws Exception;
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/WordService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/WordService.java
@@ -1,7 +1,9 @@
 package com.spring.wordseed.service;
 
 import com.spring.wordseed.dto.in.CreateWordInDTO;
+import com.spring.wordseed.dto.in.ReadWordInDTOs;
 import com.spring.wordseed.dto.out.ReadWordByDateOutDTO;
+import com.spring.wordseed.dto.out.ReadWordOutDTOs;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -10,4 +12,5 @@ import java.time.LocalDate;
 public interface WordService {
     long createWord(CreateWordInDTO createWordInDTO) throws Exception;
     ReadWordByDateOutDTO readWordByDate(LocalDate date) throws Exception;
+    ReadWordOutDTOs readWords(ReadWordInDTOs readWordInDTOs);
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/WordServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/WordServiceImpl.java
@@ -1,0 +1,31 @@
+package com.spring.wordseed.service.impl;
+
+import com.spring.wordseed.dto.in.CreateWordInDTO;
+import com.spring.wordseed.entity.Word;
+import com.spring.wordseed.repo.WordRepo;
+import com.spring.wordseed.service.WordService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class WordServiceImpl implements WordService {
+    private final WordRepo wordRepo;
+
+    @Autowired
+    public WordServiceImpl(WordRepo wordRepo) {
+        this.wordRepo = wordRepo;
+    }
+
+    @Override
+    public long createWord(CreateWordInDTO createWordInDTO) throws Exception {
+        if(createWordInDTO.getWord().length() == 0) throw new IllegalArgumentException();
+        Word word = Word.builder()
+                .word(createWordInDTO.getWord())
+                .date(createWordInDTO.getDate())
+                .build();
+        word = wordRepo.save(word);
+        return word.getWordId();
+    }
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/WordServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/WordServiceImpl.java
@@ -1,15 +1,22 @@
 package com.spring.wordseed.service.impl;
 
 import com.spring.wordseed.dto.in.CreateWordInDTO;
+import com.spring.wordseed.dto.in.ReadWordInDTOs;
 import com.spring.wordseed.dto.out.ReadWordByDateOutDTO;
+import com.spring.wordseed.dto.out.ReadWordOutDTOs;
+import com.spring.wordseed.dto.tool.WordDTO;
 import com.spring.wordseed.entity.Word;
 import com.spring.wordseed.repo.WordRepo;
 import com.spring.wordseed.service.WordService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
@@ -40,6 +47,28 @@ public class WordServiceImpl implements WordService {
                 .wordId(word.getWordId())
                 .word(word.getWord())
                 .date(word.getDate())
+                .build();
+    }
+
+    @Override
+    public ReadWordOutDTOs readWords(ReadWordInDTOs readWordInDTOs) {
+        Sort sort = Sort.by(Sort.Direction.DESC, "date");
+        if(readWordInDTOs.getQuery().length() > 0)
+            sort = Sort.by(Sort.Direction.ASC, "word");
+        PageRequest pageRequest = PageRequest.of((int) readWordInDTOs.getPage(), (int) readWordInDTOs.getSize(), sort);
+        List<Word> words = wordRepo.findByWordStartsWith(readWordInDTOs.getQuery(), pageRequest)
+                .orElse(new ArrayList<>());
+        List<WordDTO> wordDTOs = new ArrayList<>();
+        for(Word word:words) {
+            WordDTO wordDTO = WordDTO.builder()
+                    .wordId(word.getWordId())
+                    .word(word.getWord())
+                    .createdAt(word.getDate())
+                    .build();
+            wordDTOs.add(wordDTO);
+        }
+        return ReadWordOutDTOs.builder()
+                .words(wordDTOs)
                 .build();
     }
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/WordServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/WordServiceImpl.java
@@ -1,12 +1,15 @@
 package com.spring.wordseed.service.impl;
 
 import com.spring.wordseed.dto.in.CreateWordInDTO;
+import com.spring.wordseed.dto.out.ReadWordByDateOutDTO;
 import com.spring.wordseed.entity.Word;
 import com.spring.wordseed.repo.WordRepo;
 import com.spring.wordseed.service.WordService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 @Service
 @Transactional
@@ -27,5 +30,16 @@ public class WordServiceImpl implements WordService {
                 .build();
         word = wordRepo.save(word);
         return word.getWordId();
+    }
+
+    @Override
+    public ReadWordByDateOutDTO readWordByDate(LocalDate date) throws Exception {
+        Word word = wordRepo.findFirstByDate(date)
+                .orElseThrow(IllegalArgumentException::new);
+        return ReadWordByDateOutDTO.builder()
+                .wordId(word.getWordId())
+                .word(word.getWord())
+                .date(word.getDate())
+                .build();
     }
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/WordServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/WordServiceImpl.java
@@ -55,7 +55,9 @@ public class WordServiceImpl implements WordService {
         Sort sort = Sort.by(Sort.Direction.DESC, "date");
         if(readWordInDTOs.getQuery().length() > 0)
             sort = Sort.by(Sort.Direction.ASC, "word");
-        PageRequest pageRequest = PageRequest.of((int) readWordInDTOs.getPage(), (int) readWordInDTOs.getSize(), sort);
+        long page = (readWordInDTOs.getPage() - 1);
+        if(page < 0) page = 0;
+        PageRequest pageRequest = PageRequest.of((int) page, (int) readWordInDTOs.getSize(), sort);
         List<Word> words = wordRepo.findByWordStartsWith(readWordInDTOs.getQuery(), pageRequest)
                 .orElse(new ArrayList<>());
         List<WordDTO> wordDTOs = new ArrayList<>();


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- 말씨 등록/조회 API 구현

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### Feat: 추가 - 말씨 등록 API 구현 - 39a4644259976fbb9387af6c9702ec38cc272bf2
- 말씨를 직접 등록할 수 있게 임의로 만든 API입니다.
- 입력 형식은 사진 첨부합니다.
### Feat: 추가 - 오늘 말씨 조회- 8f3b0508195df4d8e8319dfd0743656ffbeecf4f
- 특정 날짜로 말씨를 조회하는 API 입니다.
- 말씨의 date를 유니크 컬럼으로 변경하여 중복을 제거하였습니다.
### Feat: 추가 - 말씨 목록 조회 - 050e8763b6aedb162031f668c902008cf29348c6
- 말씨 목록을 query가 없을 때 최신순으로, query가 있을 때 사전순으로 가져옵니다.
- page와 size로 페이지에 따라 조회할 수 있습니다.
### Fix: 추가 - 0 이하 페이지 요청 시 로직 수정 - d413777a2cf86242b090f41f7cbc3805f6c70e9c
- page는 1-base로 데이터를 조회하는데 0 이하의 값이 오면 첫 번째 페이지로 처리합니다.

## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->
- [X] PostMan Check

## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->
- size의 경우에도 MAX를 정해서 처리하는 방법을 공통 상수 설계 시 추가할 예정입니다.

## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
- 말씨 등록 RequestBody
![image](https://github.com/Project-0123/0123/assets/33569961/4885184a-265a-4649-b99a-2644baebdc93)
- 말씨 목록 조회 QueryString
![image](https://github.com/Project-0123/0123/assets/33569961/6abd7db3-cfee-4838-a41b-72775298f4d6)
- 오늘 말씨 조회 QueryString
![image](https://github.com/Project-0123/0123/assets/33569961/ebf3d376-5ec4-4225-927e-ea07a7a7c4d5)

