### PR TITLE
#97: 유저 조회

### DIFF
--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/UserController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/UserController.java
@@ -56,7 +56,8 @@ public class UserController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<ReadUserOutDTOs> readUsers(@ModelAttribute ReadUserInDTOs readUserInDTOs, HttpServletRequest request) throws Exception {
+    public ResponseEntity<ReadUserOutDTOs> readUsers(@ModelAttribute ReadUserInDTOs readUserInDTOs,
+                                                     HttpServletRequest request) throws Exception {
         long userId = (long) request.getAttribute("userId");
         readUserInDTOs.setUserId(userId);
         ReadUserOutDTOs readUserOutDTOs = userService.readUsers(readUserInDTOs);
@@ -64,15 +65,10 @@ public class UserController {
     }
 
     @GetMapping("/info")
-    public ResponseEntity<ReadUserInfoByIdOutDTO> readUserInfoById(@RequestParam("userId") long userId) throws Exception {
-        ReadUserInfoByIdOutDTO readUserInfoByIdOutDTO = ReadUserInfoByIdOutDTO.builder()
-                .userId(userId)
-                .userName("딸기 신부")
-                .userDecp("형편없는 내 글을 견디면서 글을 쭉 써보자")
-                .postCnt(15)
-                .recvCnt(50)
-                .sendCnt(10)
-                .build();
+    public ResponseEntity<ReadUserInfoByIdOutDTO> readUserInfoById(@RequestParam("userId") long dstUserId,
+                                                                   HttpServletRequest request) throws Exception {
+        long srcUserId = (long) request.getAttribute("userId");
+        ReadUserInfoByIdOutDTO readUserInfoByIdOutDTO = userService.readUserInfo(srcUserId, dstUserId);
         return ResponseEntity.status(HttpStatus.OK).body(readUserInfoByIdOutDTO);
     }
     @GetMapping("/follow") // out dto에 구독자인지 관심작가인지 enum 만들어서 보내주는 것도 좋을듯?

--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/UserController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/UserController.java
@@ -2,6 +2,7 @@ package com.spring.wordseed.controller;
 
 import com.spring.wordseed.dto.in.CreateFollowInDTO;
 import com.spring.wordseed.dto.in.DeleteFollowInDTO;
+import com.spring.wordseed.dto.in.ReadUserInDTOs;
 import com.spring.wordseed.dto.in.UpdateUserInDTO;
 import com.spring.wordseed.dto.out.*;
 import com.spring.wordseed.dto.tool.UserDTO;
@@ -55,22 +56,10 @@ public class UserController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<ReadUserOutDTOs> readUsers(@RequestParam("query") String query,
-                                                     @RequestParam("page") long page,
-                                                     @RequestParam("size") long size) throws Exception {
-        List<UserDTO> users = new ArrayList<>();
-        for(int i=1;i<=size;i++) {
-            UserDTO user = UserDTO.builder()
-                    .userId(i)
-                    .userName("" + query + page + i)
-                    .sendCnt(i* 10L)
-                    .recvCnt(i* 100L)
-                    .userDecp("언젠가 어디선가 이글을 읽는 당신에게 작은 힘이 되기를 바라본다")
-                    .subscribed((i % 2 == 0))
-                    .build();
-            users.add(user);
-        }
-        ReadUserOutDTOs readUserOutDTOs = new ReadUserOutDTOs(users);
+    public ResponseEntity<ReadUserOutDTOs> readUsers(@ModelAttribute ReadUserInDTOs readUserInDTOs, HttpServletRequest request) throws Exception {
+        long userId = (long) request.getAttribute("userId");
+        readUserInDTOs.setUserId(userId);
+        ReadUserOutDTOs readUserOutDTOs = userService.readUsers(readUserInDTOs);
         return ResponseEntity.status(HttpStatus.OK).body(readUserOutDTOs);
     }
 

--- a/back/wordseed/src/main/java/com/spring/wordseed/dto/in/ReadUserInDTOs.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/dto/in/ReadUserInDTOs.java
@@ -1,0 +1,17 @@
+package com.spring.wordseed.dto.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadUserInDTOs {
+    long userId;
+    String query;
+    long page;
+    long size;
+}

--- a/back/wordseed/src/main/java/com/spring/wordseed/dto/out/ReadUserInfoByIdOutDTO.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/dto/out/ReadUserInfoByIdOutDTO.java
@@ -1,27 +1,18 @@
 package com.spring.wordseed.dto.out;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class ReadUserInfoByIdOutDTO {
     long userId;
     String userName;
     String userDecp;
     long postCnt;
-    long recvCnt;
     long sendCnt;
-    @Builder
-    public ReadUserInfoByIdOutDTO(long userId, String userName, String userDecp, long postCnt, long recvCnt, long sendCnt) {
-        this.userId = userId;
-        this.userName = userName;
-        this.userDecp = userDecp;
-        this.postCnt = postCnt;
-        this.recvCnt = recvCnt;
-        this.sendCnt = sendCnt;
-    }
+    long recvCnt;
+    boolean subscribed;
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/dto/tool/UserDTO.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/dto/tool/UserDTO.java
@@ -1,13 +1,12 @@
 package com.spring.wordseed.dto.tool;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class UserDTO {
     long userId;
     String userName;
@@ -15,13 +14,4 @@ public class UserDTO {
     long recvCnt;
     String userDecp;
     boolean subscribed;
-    @Builder
-    public UserDTO(long userId, String userName, long sendCnt, long recvCnt, String userDecp, boolean subscribed) {
-        this.userId = userId;
-        this.userName = userName;
-        this.sendCnt = sendCnt;
-        this.recvCnt = recvCnt;
-        this.userDecp = userDecp;
-        this.subscribed = subscribed;
-    }
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/UserRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/UserRepo.java
@@ -5,6 +5,7 @@ import com.spring.wordseed.repo.custom.CustomUserRepo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+
 @Repository
 public interface UserRepo extends JpaRepository<User, Long>, CustomUserRepo {
 

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomUserRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomUserRepo.java
@@ -1,9 +1,13 @@
 package com.spring.wordseed.repo.custom;
 
+import com.spring.wordseed.dto.out.ReadUserOutDTOs;
+import com.spring.wordseed.dto.tool.UserDTO;
 import com.spring.wordseed.entity.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CustomUserRepo {
     Optional<User> findWithUserInfoById(long userId) throws Exception;
+    Optional<List<UserDTO>> findUserBy(long userId, String query, long page, long size);
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomUserRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomUserRepo.java
@@ -1,5 +1,6 @@
 package com.spring.wordseed.repo.custom;
 
+import com.spring.wordseed.dto.out.ReadUserInfoByIdOutDTO;
 import com.spring.wordseed.dto.out.ReadUserOutDTOs;
 import com.spring.wordseed.dto.tool.UserDTO;
 import com.spring.wordseed.entity.User;
@@ -10,4 +11,5 @@ import java.util.Optional;
 public interface CustomUserRepo {
     Optional<User> findWithUserInfoById(long userId) throws Exception;
     Optional<List<UserDTO>> findUserBy(long userId, String query, long page, long size);
+    Optional<ReadUserInfoByIdOutDTO> findUserInfoBy(long srcUserId, long dstUserId);
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomUserRepoImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomUserRepoImpl.java
@@ -1,6 +1,11 @@
 package com.spring.wordseed.repo.custom.impl;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
+import com.spring.wordseed.dto.tool.UserDTO;
+import com.spring.wordseed.entity.QFollow;
 import com.spring.wordseed.entity.QUser;
 import com.spring.wordseed.entity.QUserInfo;
 import com.spring.wordseed.entity.User;
@@ -8,6 +13,7 @@ import com.spring.wordseed.repo.custom.CustomUserRepo;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
+import java.util.List;
 import java.util.Optional;
 
 public class CustomUserRepoImpl implements CustomUserRepo {
@@ -15,6 +21,7 @@ public class CustomUserRepoImpl implements CustomUserRepo {
     EntityManager em;
     private final QUser qUser = QUser.user;
     private final QUserInfo qUserInfo = QUserInfo.userInfo;
+    private final QFollow qFollow = QFollow.follow;
 
     @Override
     public Optional<User> findWithUserInfoById(long userId) throws Exception {
@@ -26,4 +33,36 @@ public class CustomUserRepoImpl implements CustomUserRepo {
                 .fetchOne();
         return Optional.ofNullable(user);
     }
+
+    @Override
+    public Optional<List<UserDTO>> findUserBy(long userId, String query, long page, long size) {
+        List<UserDTO> users = new JPAQuery<>(em)
+                .select(Projections.constructor(UserDTO.class,
+                        qUser.userId,
+                        qUser.userName,
+                        qUserInfo.followSrcCnt,
+                        qUserInfo.followDstCnt,
+                        qUserInfo.userDecp,
+                        isSubscribedBy(userId)))
+                .from(qUser)
+                .innerJoin(qUser.userInfo, qUserInfo)
+                .where(qUser.userName.like(query + "%"))
+                .orderBy(qUser.userName.asc())
+                .offset((page - 1) * size)
+                .limit(size)
+                .fetch();
+
+        return Optional.ofNullable(users);
+    }
+
+    private BooleanExpression isSubscribedBy(long srcUserId) {
+        return JPAExpressions
+                .selectOne()
+                .from(qFollow)
+                .where(qFollow.srcUser.userId.eq(srcUserId))
+                .where(qFollow.dstUser.userId.eq(qUser.userId))
+                .exists();
+    }
+
+
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/UserService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/UserService.java
@@ -3,6 +3,7 @@ package com.spring.wordseed.service;
 import com.spring.wordseed.dto.in.CreateUserInDTO;
 import com.spring.wordseed.dto.in.ReadUserInDTOs;
 import com.spring.wordseed.dto.in.UpdateUserInDTO;
+import com.spring.wordseed.dto.out.ReadUserInfoByIdOutDTO;
 import com.spring.wordseed.dto.out.ReadUserOutDTO;
 import com.spring.wordseed.dto.out.ReadUserOutDTOs;
 import com.spring.wordseed.dto.out.UpdateUserOutDTO;
@@ -15,4 +16,5 @@ public interface UserService {
     UpdateUserOutDTO updateUser(UpdateUserInDTO updateUserInDTO) throws Exception;
 
     ReadUserOutDTOs readUsers(ReadUserInDTOs readUserInDTOs)throws Exception;
+    ReadUserInfoByIdOutDTO readUserInfo(long srcUserId, long dstUserId) throws Exception;
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/UserService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/UserService.java
@@ -1,8 +1,10 @@
 package com.spring.wordseed.service;
 
 import com.spring.wordseed.dto.in.CreateUserInDTO;
+import com.spring.wordseed.dto.in.ReadUserInDTOs;
 import com.spring.wordseed.dto.in.UpdateUserInDTO;
 import com.spring.wordseed.dto.out.ReadUserOutDTO;
+import com.spring.wordseed.dto.out.ReadUserOutDTOs;
 import com.spring.wordseed.dto.out.UpdateUserOutDTO;
 import org.springframework.stereotype.Service;
 
@@ -11,4 +13,6 @@ public interface UserService {
     long createUser(CreateUserInDTO createUserInDTO) throws Exception;
     ReadUserOutDTO readUser(long userId) throws Exception;
     UpdateUserOutDTO updateUser(UpdateUserInDTO updateUserInDTO) throws Exception;
+
+    ReadUserOutDTOs readUsers(ReadUserInDTOs readUserInDTOs)throws Exception;
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.spring.wordseed.service.impl;
 import com.spring.wordseed.dto.in.CreateUserInDTO;
 import com.spring.wordseed.dto.in.ReadUserInDTOs;
 import com.spring.wordseed.dto.in.UpdateUserInDTO;
+import com.spring.wordseed.dto.out.ReadUserInfoByIdOutDTO;
 import com.spring.wordseed.dto.out.ReadUserOutDTO;
 import com.spring.wordseed.dto.out.ReadUserOutDTOs;
 import com.spring.wordseed.dto.out.UpdateUserOutDTO;
@@ -98,5 +99,10 @@ public class UserServiceImpl implements UserService {
         return ReadUserOutDTOs.builder()
                 .users(users)
                 .build();
+    }
+
+    @Override
+    public ReadUserInfoByIdOutDTO readUserInfo(long srcUserId, long dstUserId) throws Exception {
+        return userRepo.findUserInfoBy(srcUserId, dstUserId).orElseThrow(IllegalArgumentException::new);
     }
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
@@ -94,6 +94,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public ReadUserOutDTOs readUsers(ReadUserInDTOs readUserInDTOs) throws Exception {
+        if(readUserInDTOs.getPage() < 1) readUserInDTOs.setPage(1);
         List<UserDTO> users = userRepo.findUserBy(readUserInDTOs.getUserId(), readUserInDTOs.getQuery(),
                 readUserInDTOs.getPage(), readUserInDTOs.getSize()).orElse(new ArrayList<>());
         return ReadUserOutDTOs.builder()

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/UserServiceImpl.java
@@ -1,9 +1,12 @@
 package com.spring.wordseed.service.impl;
 
 import com.spring.wordseed.dto.in.CreateUserInDTO;
+import com.spring.wordseed.dto.in.ReadUserInDTOs;
 import com.spring.wordseed.dto.in.UpdateUserInDTO;
 import com.spring.wordseed.dto.out.ReadUserOutDTO;
+import com.spring.wordseed.dto.out.ReadUserOutDTOs;
 import com.spring.wordseed.dto.out.UpdateUserOutDTO;
+import com.spring.wordseed.dto.tool.UserDTO;
 import com.spring.wordseed.entity.User;
 import com.spring.wordseed.entity.UserInfo;
 import com.spring.wordseed.enu.Informable;
@@ -12,8 +15,13 @@ import com.spring.wordseed.repo.UserInfoRepo;
 import com.spring.wordseed.repo.UserRepo;
 import com.spring.wordseed.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
@@ -80,6 +88,15 @@ public class UserServiceImpl implements UserService {
                 .informable(user.getUserInfo().getInformable())
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+
+    @Override
+    public ReadUserOutDTOs readUsers(ReadUserInDTOs readUserInDTOs) throws Exception {
+        List<UserDTO> users = userRepo.findUserBy(readUserInDTOs.getUserId(), readUserInDTOs.getQuery(),
+                readUserInDTOs.getPage(), readUserInDTOs.getSize()).orElse(new ArrayList<>());
+        return ReadUserOutDTOs.builder()
+                .users(users)
                 .build();
     }
 }


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- 작가 조회와 유저 정보 조회 (유저페이지) 입니다.
- 구독 여부를 묻는 로직이 공통 적용되어 같이 구현했습니다.

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### Feat: 추가 - 작가 조회 API 구현 - 8ef26814e31f9228b96ff41836b12d90c8785a15
- QueryDSL로 DTO를 반환하도록 구현했습니다.
- query로 부터 시작되는 유저를 사전 순으로 페이징 처리해서 반환합니다.
- subscribed는 API를 요청한 userId와 qUser.userId로 찾는 서브 쿼리를 사용했습니다.
### Feat: 추가 - 유저 정보 조회(유저 페이지) API 구현 - c2af321d4e47788c2d3ec6edd7a6ce33b784fa68
- 마찬가지로 QueryDSL로 DTO를 반환하도록 구현했습니다.
- subscribed를 구할 때, srcUserId, dstUserId로 찾는 서브 쿼리를 사용했습니다.
### Fix: 수정 - 0 이하 페이지 요청 시 로직 추가 - 7bf1bde72b3eb80fbf2d20f6b1baf5ea5914c92c
- 페이지는 1-base이기 때문에 0이하의 값이 들어오면 첫 번째 페이지를 요청하도록 수정했습니다.
## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->
- [X] PostMan Check

## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->
- isSubscribedBy를 오버로딩해서 구현했는데, where절 부분을 메소드화해서 중복을 최대한 줄일 수 있도록 수정하겠습니다.

## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
