### PR TITLE
#169: wordseedlist & artistcardlist 컴포넌트와  search 페이지 리팩토링

### DIFF
--- a/front/src/app/search/_component/search-list.tsx
+++ b/front/src/app/search/_component/search-list.tsx
@@ -1,18 +1,53 @@
 "use client";
 
+import { useInView } from "react-intersection-observer";
+import { useWordseedList } from "@/api/wordseed";
+import { useAuthorList } from "@/api/author";
 import useSearchPageStateStore from "@/stores/search-page";
 import SearchGuidance from "./search-guidance";
 import { WordSeedList } from "@/components";
 import { ArtistCardList } from "@/components";
+
 import style from "./search.module.scss";
 
 export default function SearchList() {
   const { searchKeyword, isWordseed } = useSearchPageStateStore();
+
+  const {
+    status: wordseedListStatus,
+    data: wordseedListData,
+    fetchNextPage: wordseedListFetchNextPage,
+  } = useWordseedList({
+    params: {
+      query: searchKeyword,
+    },
+  });
+
+  const {
+    status: authorListStatus,
+    data: authorListData,
+    fetchNextPage: authorListFetchNextPage,
+  } = useAuthorList({
+    params: {
+      query: searchKeyword,
+    },
+  });
+
   return (
     <div className={style["list-container"]}>
       {!searchKeyword && <SearchGuidance />}
-      {searchKeyword && isWordseed && <WordSeedList />}
-      {searchKeyword && !isWordseed && <ArtistCardList />}
+      {searchKeyword && isWordseed && (
+        <WordSeedList
+          data={wordseedListData?.pages}
+          fetchNextPage={wordseedListFetchNextPage}
+        />
+      )}
+      {searchKeyword && !isWordseed && (
+        <ArtistCardList
+          data={authorListData?.pages}
+          fetchNextPage={authorListFetchNextPage}
+        />
+      )}
     </div>
   );
 }

--- a/front/src/components/ArtistCardList/ArtistCardList.tsx
+++ b/front/src/components/ArtistCardList/ArtistCardList.tsx
@@ -1,64 +1,40 @@
 "use client";
+
 import { useInView } from "react-intersection-observer";
 import { ArtistCard } from "..";
-import useSearchPageStateStore from "@/stores/search-page";
-import { useAuthorList } from "@/api/author";
+import { Author } from "@/api/author/types";
+import { ArtistCardListFetchNextPage } from "./types";
 import styles from "./ArtistCardList.module.scss";
 
-// route 판별해서 관심작가 목록 페이지이면 관심작가 데이터 조회하는 요청
-// search 페이지이면 아래와 같이 요청
+type ArtistCardListProps = {
+  data: Author[] | undefined;
+  fetchNextPage: ArtistCardListFetchNextPage;
+};
 
-export default function ArtistCardList() {
-  const { searchKeyword } = useSearchPageStateStore();
-  const { status, data, fetchNextPage } = useAuthorList({
-    params: {
-      query: searchKeyword,
-    },
-  });
-
+export default function ArtistCardList({
+  data,
+  fetchNextPage,
+}: ArtistCardListProps) {
   const [ref] = useInView({
     onChange: (inView) => {
       if (inView) fetchNextPage();
     },
   });
+
   return (
     <div className={styles.container}>
-      {status === "success" && data.pages.length === 0 && (
-        <>{searchKeyword} 데이터 없음</>
-      )}
-      {status === "success" && (
-        <>
-          {data.pages.map((Author, idx) => (
-            <div
-              key={idx}
-              ref={idx === data.pages.length - 5 ? ref : undefined}
-            >
-              <ArtistCard
-                userId={Author.userId}
-                userName={Author.userName}
-                userDecp={Author.userDecp}
-                recvCnt={Author.recvCnt}
-                sendCnt={Author.sendCnt}
-                subscribed={Author.subscribed}
-              />
-            </div>
-          ))}
-        </>
-      )}
+      {data?.map((Author, idx) => (
+        <div key={idx} ref={idx === data.length - 5 ? ref : undefined}>
+          <ArtistCard
+            userId={Author.userId}
+            userName={Author.userName}
+            userDecp={Author.userDecp}
+            recvCnt={Author.recvCnt}
+            sendCnt={Author.sendCnt}
+            subscribed={Author.subscribed}
+          />
+        </div>
+      ))}
     </div>
   );
-}
-
-{
-  /* {datas.map((data) => (
-  <ArtistCard
-    key={data.userId}
-    userId={data.userId}
-    userName={data.userName}
-    userDecp={data.userDecp}
-    recvCnt={data.recvCnt}
-    sendCnt={data.sendCnt}
-    subscribed={data.subscribed}
-  />
-))} */
 }

--- a/front/src/components/ArtistCardList/types.ts
+++ b/front/src/components/ArtistCardList/types.ts
@@ -1,0 +1,16 @@
+import { FetchNextPageOptions } from "@tanstack/react-query";
+import { InfiniteQueryObserverResult } from "@tanstack/react-query";
+import { Author } from "@/api/author/types";
+import { AxiosError } from "axios";
+
+export type ArtistCardListFetchNextPage = (
+  options?: FetchNextPageOptions | undefined
+) => Promise<
+  InfiniteQueryObserverResult<
+    {
+      pages: Author[];
+      pageParams: number[];
+    },
+    AxiosError<unknown, any>
+  >
+>;

--- a/front/src/components/WordSeedList/WordSeedList.tsx
+++ b/front/src/components/WordSeedList/WordSeedList.tsx
@@ -1,21 +1,20 @@
 "use client";
+
 import { useInView } from "react-intersection-observer";
 import Wordseed from "@/components/WordSeed/WordSeed";
-import NoData from "./component/no-data";
-import useSearchPageStateStore from "@/stores/search-page";
-import { useWordseedList } from "@/api/wordseed";
+import { Wordseed as Wordseedtype } from "@/api/wordseed/types";
+import { WordseedListFetchNextPage } from "./types";
 import styles from "./WordSeedList.module.scss";
 
-// route 판별해서 말씨 목록 페이지이면 모든 데이터 조회하는 요청
-// search 페이지이면 아래와 같이 요청
+type WordSeedListProps = {
+  data: Wordseedtype[] | undefined;
+  fetchNextPage: WordseedListFetchNextPage;
+};
 
-export default function WordSeedList() {
-  const { searchKeyword } = useSearchPageStateStore();
-  const { status, data, fetchNextPage } = useWordseedList({
-    params: {
-      query: searchKeyword,
-    },
-  });
+export default function WordSeedList({
+  data,
+  fetchNextPage,
+}: WordSeedListProps) {
   const [ref] = useInView({
     onChange: (inView) => {
       if (inView) fetchNextPage();
@@ -24,26 +23,14 @@ export default function WordSeedList() {
 
   return (
     <div className={styles.container}>
-      {/* {status === "pending" && <p>Loading...</p>} */}
-      {status === "success" && data.pages.length === 0 && (
-        <NoData searchKeyword={searchKeyword} />
-      )}
-      {status === "success" && (
-        <>
-          {data.pages.map((wordseed, idx) => (
-            <div
-              key={idx}
-              ref={idx === data.pages.length - 5 ? ref : undefined}
-            >
-              <Wordseed
-                // 나중에는 key값을 날짜로 수정해야함
-                date={wordseed.createdAt}
-                wordseed={wordseed.word}
-              />
-            </div>
-          ))}
-        </>
-      )}
+      {data?.map((wordseed, idx) => (
+        <div
+          key={wordseed.createdAt}
+          ref={idx === data.length - 5 ? ref : undefined}
+        >
+          <Wordseed date={wordseed.createdAt} wordseed={wordseed.word} />
+        </div>
+      ))}
     </div>
   );
 }

--- a/front/src/components/WordSeedList/types.ts
+++ b/front/src/components/WordSeedList/types.ts
@@ -1,0 +1,16 @@
+import { FetchNextPageOptions } from "@tanstack/react-query";
+import { InfiniteQueryObserverResult } from "@tanstack/react-query";
+import { Wordseed } from "@/api/wordseed/types";
+import { AxiosError } from "axios";
+
+export type WordseedListFetchNextPage = (
+  options?: FetchNextPageOptions | undefined
+) => Promise<
+  InfiniteQueryObserverResult<
+    {
+      pages: Wordseed[];
+      pageParams: number[];
+    },
+    AxiosError<unknown, any>
+  >
+>;


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- wordseedlist & artistcardlist 컴포넌트 안에서 데이터를 요청하는 방식으로 구현했었음
- 그러나 다른 페이지에서도 이 컴포넌트를 사용하기 때문에 search 페이지 컴포넌트에서 data를 요청하고 이 data를 prop 주는 방식으로 수정

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### wordseedlist & artistcardlist 데이터 사용 방법 수정 - e6a208d72bf558a71b485f88cbee47856cb770b2
- search 페이지 컴포넌트에서 데이터 요청 후 각 컴포넌트에 data와 fetchNextPage를 prop 줌
- wordseedlist & artistcardlist 컴포넌트는 data와 fetchNextPage 함수만 prop 받음

## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->


## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
