### PR TITLE
#171: search 페이지 리팩토링 - 중복 요청 처리

### DIFF
--- a/front/src/app/search/_component/search-guidance.tsx
+++ b/front/src/app/search/_component/search-guidance.tsx
@@ -1,5 +1,15 @@
 import style from "./search.module.scss";
 
-export default function SearchGuidance() {
-  return <p className={style["guidance"]}>검색어를 입력해 주세요.</p>;
+type SearchGuidanceProps = {
+  searchKeyword?: string;
+};
+
+export default function SearchGuidance({ searchKeyword }: SearchGuidanceProps) {
+  return (
+    <p className={style["guidance"]}>
+      {searchKeyword
+        ? `${searchKeyword}에 대한 검색 결과가 없습니다.`
+        : "검색어를 입력해 주세요."}
+    </p>
+  );
 }

--- a/front/src/app/search/_component/search-list.tsx
+++ b/front/src/app/search/_component/search-list.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useInView } from "react-intersection-observer";
 import { useWordseedList } from "@/api/wordseed";
 import { useAuthorList } from "@/api/author";
 import useSearchPageStateStore from "@/stores/search-page";
@@ -21,6 +20,7 @@ export default function SearchList() {
     params: {
       query: searchKeyword,
     },
+    config: { enabled: isWordseed && !!searchKeyword },
   });
 
   const {
@@ -31,6 +31,7 @@ export default function SearchList() {
     params: {
       query: searchKeyword,
     },
+    config: { enabled: !isWordseed && !!searchKeyword },
   });
 
   return (

--- a/front/src/app/search/_component/search-list.tsx
+++ b/front/src/app/search/_component/search-list.tsx
@@ -37,12 +37,22 @@ export default function SearchList() {
   return (
     <div className={style["list-container"]}>
       {!searchKeyword && <SearchGuidance />}
+
+      {searchKeyword &&
+        ((wordseedListStatus === "success" &&
+          wordseedListData.pages.length === 0) ||
+          (authorListStatus === "success" &&
+            authorListData.pages.length === 0)) && (
+          <SearchGuidance searchKeyword={searchKeyword} />
+        )}
+
       {searchKeyword && isWordseed && (
         <WordSeedList
           data={wordseedListData?.pages}
           fetchNextPage={wordseedListFetchNextPage}
         />
       )}
+
       {searchKeyword && !isWordseed && (
         <ArtistCardList
           data={authorListData?.pages}

--- a/front/src/lib/react-query.ts
+++ b/front/src/lib/react-query.ts
@@ -52,11 +52,14 @@ export type MutationConfig<MutationFnType extends (...args: any) => any> =
   >;
 
 export type InfiniteQueryConfig<QueryFnType extends (...args: any) => any> =
-  UseInfiniteQueryOptions<
-    ExtractFnReturnType<QueryFnType>,
-    AxiosError,
-    ExtractFnReturnType<QueryFnType>,
-    ExtractFnReturnType<QueryFnType>,
-    Array<string | Parameters<QueryFnType>[0]>,
-    number
+  Omit<
+    UseInfiniteQueryOptions<
+      ExtractFnReturnType<QueryFnType>,
+      AxiosError,
+      ExtractFnReturnType<QueryFnType>,
+      ExtractFnReturnType<QueryFnType>,
+      Array<string | Parameters<QueryFnType>[0]>,
+      number
+    >,
+    "queryKey" | "getNextPageParam" | "initialPageParam"
   >;


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- search 페이지 말씨 목록 조회, 작가 목록 조회 중복 요청 처리
- search 페이지 안내 문구 분기 처리

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### inifiniteInfiniteQueryConfig 수정 - d7d7ef36150f97e63a560f5d38ee5411448819e3
- InfiniteQuery의 필수 옵션은 queryKey, getNextPageParam, initialPageParam
- 필수 옵션은 hook을 만들 때 입력하기 때문에 hook을 사용할 때 추가로 입력하는 config option에는 필수 요소를 기재할 필요가 없음
- 따라서 hook을 사용할 때 입력하는 config의 타입인 InfiniteQueryConfig에서 필수 옵션을 Omit함
### 중복 쿼리 요청 처리 - 80622b2db6df697ed11b84127e92f1606d1e1000
- React Query hook의 config 중 enabled 사용
- searchKeyword(검색어)가 있으면서 말씨 버튼이 눌려있을 때만 wordseedlist 요청
- searchKeyword가 있으면서 작가 버튼이 눌려있을 때만 authorlist 요청
### search 페이지 안내 문구 렌더링 분기 처리 - 3ed9cdb495b8ed9333e1cc31296509ab93e1f509
- 자식 컴포넌트에서 noData 분기처리를 했으나 search 페이지 컴포넌트에서 직접 분기처리하는 방법으로 수정

## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->


## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
