### PR TITLE
#183: postService method: query, mark 파라미터 제거

### DIFF
--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
@@ -60,48 +60,44 @@ public class PostController {
     // 관심 작가로 등록한 사람들의 작품 목록 조회
     @GetMapping("/list/subs")
     public ResponseEntity<ReadPostByPostIdOutDTOs> readPostsWithSubs(@RequestParam("postType") String postType,
-                                                             @RequestParam("mark") String mark,
                                                              @RequestParam("sort") PostSort sort,
                                                              @RequestParam(value = "query", required = false, defaultValue = "") String query,
                                                              @RequestParam("page") Long page,
                                                              @RequestParam("size") Long size,
                                                              HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithSubs(postType, mark, sort, query, page, size, srcUserId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithSubs(postType, sort, query, page, size, srcUserId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
     // 나의 작품 목록 조회
     @GetMapping("/list/self")
     public ResponseEntity<ReadPostByPostIdOutDTOs> readMyPosts(@RequestParam("postType") String postType,
-                                                             @RequestParam("mark") String mark,
                                                              @RequestParam("sort") PostSort sort,
                                                              @RequestParam(value = "query", required = false, defaultValue = "") String query,
                                                              @RequestParam("page") Long page,
                                                              @RequestParam("size") Long size,
                                                              HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readMyPosts(postType, mark, sort, query, page, size, srcUserId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readMyPosts(postType, sort, query, page, size, srcUserId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
     
     // 내가 북마크한 작품 목록 조회
     @GetMapping("/list/book-mark")
     public ResponseEntity<ReadPostByPostIdOutDTOs> readMyPostsWithBookMark(@RequestParam("postType") String postType,
-                                                       @RequestParam("mark") String mark,
                                                        @RequestParam("sort") PostSort sort,
                                                        @RequestParam(value = "query", required = false, defaultValue = "") String query,
                                                        @RequestParam("page") Long page,
                                                        @RequestParam("size") Long size,
                                                        HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readMyPostsWithBookMark(postType, mark, sort, query, page, size, srcUserId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readMyPostsWithBookMark(postType, sort, query, page, size, srcUserId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
     
     // 특정 사용자에 대한 작품 목록 조회
     @GetMapping("/list/user")
     public ResponseEntity<ReadPostByPostIdOutDTOs> readPostsWithUser(@RequestParam("postType") String postType,
-                                                             @RequestParam("mark") String mark,
                                                              @RequestParam(value = "userId", required = false, defaultValue = "0") Long userId,
                                                              @RequestParam("sort") PostSort sort,
                                                              @RequestParam(value = "query", required = false, defaultValue = "") String query,
@@ -109,7 +105,7 @@ public class PostController {
                                                              @RequestParam("size") Long size,
                                                              HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithUser(postType, mark, userId, sort, query, page, size, srcUserId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithUser(postType, userId, sort, query, page, size, srcUserId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
 

--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
@@ -53,7 +53,7 @@ public class PostController {
                                                      @RequestParam("size") Long size,
                                                      HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithWord(postType, sort,  page, size, srcUserId, wordId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithWord(postType, sort, page, size, srcUserId, wordId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
     
@@ -61,24 +61,22 @@ public class PostController {
     @GetMapping("/list/subs")
     public ResponseEntity<ReadPostByPostIdOutDTOs> readPostsWithSubs(@RequestParam("postType") String postType,
                                                              @RequestParam("sort") PostSort sort,
-                                                             @RequestParam(value = "query", required = false, defaultValue = "") String query,
                                                              @RequestParam("page") Long page,
                                                              @RequestParam("size") Long size,
                                                              HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithSubs(postType, sort, query, page, size, srcUserId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithSubs(postType, sort, page, size, srcUserId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
     // 나의 작품 목록 조회
     @GetMapping("/list/self")
     public ResponseEntity<ReadPostByPostIdOutDTOs> readMyPosts(@RequestParam("postType") String postType,
                                                              @RequestParam("sort") PostSort sort,
-                                                             @RequestParam(value = "query", required = false, defaultValue = "") String query,
                                                              @RequestParam("page") Long page,
                                                              @RequestParam("size") Long size,
                                                              HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readMyPosts(postType, sort, query, page, size, srcUserId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readMyPosts(postType, sort, page, size, srcUserId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
     
@@ -86,12 +84,11 @@ public class PostController {
     @GetMapping("/list/book-mark")
     public ResponseEntity<ReadPostByPostIdOutDTOs> readMyPostsWithBookMark(@RequestParam("postType") String postType,
                                                        @RequestParam("sort") PostSort sort,
-                                                       @RequestParam(value = "query", required = false, defaultValue = "") String query,
                                                        @RequestParam("page") Long page,
                                                        @RequestParam("size") Long size,
                                                        HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readMyPostsWithBookMark(postType, sort, query, page, size, srcUserId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readMyPostsWithBookMark(postType, sort, page, size, srcUserId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
     
@@ -100,12 +97,11 @@ public class PostController {
     public ResponseEntity<ReadPostByPostIdOutDTOs> readPostsWithUser(@RequestParam("postType") String postType,
                                                              @RequestParam(value = "userId", required = false, defaultValue = "0") Long userId,
                                                              @RequestParam("sort") PostSort sort,
-                                                             @RequestParam(value = "query", required = false, defaultValue = "") String query,
                                                              @RequestParam("page") Long page,
                                                              @RequestParam("size") Long size,
                                                              HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithUser(postType, userId, sort, query, page, size, srcUserId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithUser(postType, userId, sort, page, size, srcUserId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
 

--- a/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/controller/PostController.java
@@ -47,15 +47,13 @@ public class PostController {
     // 특정 말씨에 대한 작품 목록 조회
     @GetMapping("/list/word")
     public ResponseEntity<ReadPostByPostIdOutDTOs> readPostsWithWord(@RequestParam("postType") String postType,
-                                                     @RequestParam("mark") String mark,
                                                      @RequestParam("sort") PostSort sort,
-                                                     @RequestParam(value = "query", required = false, defaultValue = "") String query,
                                                      @RequestParam(value = "wordId", required = false, defaultValue = "0") Long wordId,
                                                      @RequestParam("page") Long page,
                                                      @RequestParam("size") Long size,
                                                      HttpServletRequest request) throws Exception {
         long srcUserId = (long) request.getAttribute("userId");
-        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithWord(postType, mark, sort, query, page, size, srcUserId, wordId);
+        ReadPostByPostIdOutDTOs readPostByPostIdOutDTOs = postService.readPostsWithWord(postType, sort,  page, size, srcUserId, wordId);
         return ResponseEntity.status(HttpStatus.OK).body(readPostByPostIdOutDTOs);
     }
     

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomPostRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomPostRepo.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public interface CustomPostRepo {
     ReadPostByPostIdOutDTO findPostByPostId(Long postId, Long srcUserId);
-    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithWord(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId, Long wordId); // 특정 말씨에 해당하는 모든 작품 목록
+    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId); // 특정 말씨에 해당하는 모든 작품 목록
     Optional<List<ReadPostByPostIdOutDTO>> findPostsWithSubs(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId); // 관심 작가 등록한 사람들의 작품 목록
     Optional<List<ReadPostByPostIdOutDTO>> findMyPosts(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId); // 내 작품 목록
     Optional<List<ReadPostByPostIdOutDTO>> findMyPostsWithBookMark(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId); // 내가 북마크한 작품 목록

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomPostRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomPostRepo.java
@@ -13,10 +13,10 @@ import java.util.Optional;
 public interface CustomPostRepo {
     ReadPostByPostIdOutDTO findPostByPostId(Long postId, Long srcUserId);
     Optional<List<ReadPostByPostIdOutDTO>> findPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId); // 특정 말씨에 해당하는 모든 작품 목록
-    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithSubs(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId); // 관심 작가 등록한 사람들의 작품 목록
-    Optional<List<ReadPostByPostIdOutDTO>> findMyPosts(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId); // 내 작품 목록
-    Optional<List<ReadPostByPostIdOutDTO>> findMyPostsWithBookMark(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId); // 내가 북마크한 작품 목록
-    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithUser(String postTypes,  Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId); // 특정 사용자에 대한 작품 목록
+    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithSubs(String postTypes,  PostSort sort, Long page, Long size, Long srcUserId); // 관심 작가 등록한 사람들의 작품 목록
+    Optional<List<ReadPostByPostIdOutDTO>> findMyPosts(String postTypes,  PostSort sort, Long page, Long size, Long srcUserId); // 내 작품 목록
+    Optional<List<ReadPostByPostIdOutDTO>> findMyPostsWithBookMark(String postTypes,  PostSort sort, Long page, Long size, Long srcUserId); // 내가 북마크한 작품 목록
+    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithUser(String postTypes,  Long userId, PostSort sort, Long page, Long size, Long srcUserId); // 특정 사용자에 대한 작품 목록
     List<ReadCommentOutDTO> findCommentAllBy(Long postId, Long page, Long size);
     Optional<Post> findPostBy(Long postId, Long userId);
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomPostRepo.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/CustomPostRepo.java
@@ -13,10 +13,10 @@ import java.util.Optional;
 public interface CustomPostRepo {
     ReadPostByPostIdOutDTO findPostByPostId(Long postId, Long srcUserId);
     Optional<List<ReadPostByPostIdOutDTO>> findPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId); // 특정 말씨에 해당하는 모든 작품 목록
-    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithSubs(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId); // 관심 작가 등록한 사람들의 작품 목록
-    Optional<List<ReadPostByPostIdOutDTO>> findMyPosts(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId); // 내 작품 목록
-    Optional<List<ReadPostByPostIdOutDTO>> findMyPostsWithBookMark(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId); // 내가 북마크한 작품 목록
-    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithUser(String postTypes, String mark, Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId); // 특정 사용자에 대한 작품 목록
+    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithSubs(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId); // 관심 작가 등록한 사람들의 작품 목록
+    Optional<List<ReadPostByPostIdOutDTO>> findMyPosts(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId); // 내 작품 목록
+    Optional<List<ReadPostByPostIdOutDTO>> findMyPostsWithBookMark(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId); // 내가 북마크한 작품 목록
+    Optional<List<ReadPostByPostIdOutDTO>> findPostsWithUser(String postTypes,  Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId); // 특정 사용자에 대한 작품 목록
     List<ReadCommentOutDTO> findCommentAllBy(Long postId, Long page, Long size);
     Optional<Post> findPostBy(Long postId, Long userId);
 }

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomPostRepoImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomPostRepoImpl.java
@@ -134,7 +134,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 .where(qPost.postVisibility.eq(PostVisibility.PUBLIC).or(qPost.user.userId.eq(srcUserId)))
                 .offset((page - 1) * size)
                 .limit(size)
-                .orderBy(switch(sort){
+                .orderBy(switch (sort) {
                     case DATE_ASC -> qPost.createdAt.asc();
                     case DATE_DSC -> qPost.createdAt.desc();
                     case LIKE_ASC -> qPost.likedCnt.asc();
@@ -142,7 +142,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 })
                 .fetch();
 
-        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList){
+        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList) {
             Post likedExpression = new JPAQuery<>(em)
                     .select(qPost)
                     .from(qPost)
@@ -175,10 +175,9 @@ public class CustomPostRepoImpl implements CustomPostRepo {
     }
 
 
-
     @Override
     // 관심 작가 등록한 사람들의 작품 목록
-    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithSubs(String postTypes, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithSubs(String postTypes, PostSort sort, Long page, Long size, Long srcUserId) {
         List<PostType> postTypeList = Arrays.stream(postTypes.split(","))
                 .map(PostType::valueOf)
                 .toList();
@@ -210,10 +209,9 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 .where(qUser.userId.eq(srcUserId))
                 .where(qPost.postType.in(postTypeList))
                 .where(qPost.postVisibility.eq(PostVisibility.PUBLIC))
-                .where((query == null || query.trim().length() == 0) ? Expressions.TRUE : qPost.word.word.eq(query))
                 .offset((page - 1) * size)
                 .limit(size)
-                .orderBy(switch(sort){
+                .orderBy(switch (sort) {
                     case DATE_ASC -> qPost.createdAt.asc();
                     case DATE_DSC -> qPost.createdAt.desc();
                     case LIKE_ASC -> qPost.likedCnt.asc();
@@ -221,7 +219,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 })
                 .fetch();
 
-        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList){
+        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList) {
             Post likedExpression = new JPAQuery<>(em)
                     .select(qPost)
                     .from(qPost)
@@ -248,7 +246,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
 
     @Override
     // 내 작품 목록
-    public Optional<List<ReadPostByPostIdOutDTO>> findMyPosts(String postTypes, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+    public Optional<List<ReadPostByPostIdOutDTO>> findMyPosts(String postTypes, PostSort sort, Long page, Long size, Long srcUserId) {
         List<PostType> postTypeList = Arrays.stream(postTypes.split(","))
                 .map(PostType::valueOf)
                 .toList();
@@ -276,10 +274,9 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 .from(qPost)
                 .where(qPost.postType.in(postTypeList))
                 .where(qPost.user.userId.eq(srcUserId))
-                .where((query == null || query.trim().length() == 0) ? Expressions.TRUE : qPost.word.word.eq(query))
                 .offset((page - 1) * size)
                 .limit(size)
-                .orderBy(switch(sort){
+                .orderBy(switch (sort) {
                     case DATE_ASC -> qPost.createdAt.asc();
                     case DATE_DSC -> qPost.createdAt.desc();
                     case LIKE_ASC -> qPost.likedCnt.asc();
@@ -287,7 +284,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 })
                 .fetch();
 
-        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList){
+        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList) {
             Post likedExpression = new JPAQuery<>(em)
                     .select(qPost)
                     .from(qPost)
@@ -314,7 +311,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
 
     @Override
     // 내가 북마크한 작품 목록
-    public Optional<List<ReadPostByPostIdOutDTO>> findMyPostsWithBookMark(String postTypes, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+    public Optional<List<ReadPostByPostIdOutDTO>> findMyPostsWithBookMark(String postTypes, PostSort sort, Long page, Long size, Long srcUserId) {
         List<PostType> postTypeList = Arrays.stream(postTypes.split(","))
                 .map(PostType::valueOf)
                 .toList();
@@ -345,10 +342,9 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 .where(qUser.userId.eq(srcUserId))
                 .where(qPost.postType.in(postTypeList))
                 .where(qPost.postVisibility.eq(PostVisibility.PUBLIC).or(qPost.user.userId.eq(srcUserId)))
-                .where((query == null || query.trim().length() == 0) ? Expressions.TRUE : qPost.word.word.eq(query))
                 .offset((page - 1) * size)
                 .limit(size)
-                .orderBy(switch(sort){
+                .orderBy(switch (sort) {
                     case DATE_ASC -> qPost.createdAt.asc();
                     case DATE_DSC -> qPost.createdAt.desc();
                     case LIKE_ASC -> qPost.likedCnt.asc();
@@ -356,7 +352,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 })
                 .fetch();
 
-        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList){
+        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList) {
             Post likedExpression = new JPAQuery<>(em)
                     .select(qPost)
                     .from(qPost)
@@ -383,7 +379,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
 
     @Override
     // 특정 사용자에 대한 작품 목록
-    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithUser(String postTypes, Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithUser(String postTypes, Long userId, PostSort sort, Long page, Long size, Long srcUserId) {
         List<PostType> postTypeList = Arrays.stream(postTypes.split(","))
                 .map(PostType::valueOf)
                 .toList();
@@ -412,10 +408,9 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 .where(qPost.user.userId.eq(userId))
                 .where(qPost.postType.in(postTypeList))
                 .where(qPost.postVisibility.eq(PostVisibility.PUBLIC).or(qPost.user.userId.eq(srcUserId)))
-                .where((query == null || query.trim().length() == 0) ? Expressions.TRUE : qPost.word.word.eq(query))
                 .offset((page - 1) * size)
                 .limit(size)
-                .orderBy(switch(sort){
+                .orderBy(switch (sort) {
                     case DATE_ASC -> qPost.createdAt.asc();
                     case DATE_DSC -> qPost.createdAt.desc();
                     case LIKE_ASC -> qPost.likedCnt.asc();
@@ -430,7 +425,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 .where(qFollow.dstUser.userId.eq(userId))
                 .fetchOne();
 
-        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList){
+        for (ReadPostByPostIdOutDTO readPostByPostIdOutDTO : readPostByPostIdOutDTOList) {
             Post likedExpression = new JPAQuery<>(em)
                     .select(qPost)
                     .from(qPost)
@@ -472,7 +467,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
 
         return ReadCommentOutDTOList;
     }
-  
+
     @Override
     public Optional<Post> findPostBy(Long postId, Long userId) {
         Post post = new JPAQuery<>(em)

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomPostRepoImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomPostRepoImpl.java
@@ -103,7 +103,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
 
     @Override
     // 특정 말씨에 해당하는 모든 작품 목록
-    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithWord(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId, Long wordId) {
+    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId) {
         List<PostType> postTypeList = Arrays.stream(postTypes.split(","))
                 .map(PostType::valueOf)
                 .toList();
@@ -132,7 +132,6 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                 .where(qPost.word.wordId.eq(wordId))
                 .where(qPost.postType.in(postTypeList))
                 .where(qPost.postVisibility.eq(PostVisibility.PUBLIC).or(qPost.user.userId.eq(srcUserId)))
-                .where((query == null || query.trim().length() == 0) ? Expressions.TRUE : qPost.word.word.eq(query))
                 .offset((page - 1) * size)
                 .limit(size)
                 .orderBy(switch(sort){
@@ -171,9 +170,6 @@ public class CustomPostRepoImpl implements CustomPostRepo {
             readPostByPostIdOutDTO.setBookMarked(bookMarkedExpression != null);
             readPostByPostIdOutDTO.setSubscribed(subscribedExpression != null);
         }
-
-        if (mark.equals("true"))
-            readPostByPostIdOutDTOList.removeIf(el -> !el.getBookMarked());
 
         return Optional.ofNullable(readPostByPostIdOutDTOList);
     }

--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomPostRepoImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomPostRepoImpl.java
@@ -178,7 +178,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
 
     @Override
     // 관심 작가 등록한 사람들의 작품 목록
-    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithSubs(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithSubs(String postTypes, PostSort sort, String query, Long page, Long size, Long srcUserId) {
         List<PostType> postTypeList = Arrays.stream(postTypes.split(","))
                 .map(PostType::valueOf)
                 .toList();
@@ -243,15 +243,12 @@ public class CustomPostRepoImpl implements CustomPostRepo {
             readPostByPostIdOutDTO.setSubscribed(true);
         }
 
-        if (mark.equals("true"))
-            readPostByPostIdOutDTOList.removeIf(el -> !el.getBookMarked());
-
         return Optional.ofNullable(readPostByPostIdOutDTOList);
     }
 
     @Override
     // 내 작품 목록
-    public Optional<List<ReadPostByPostIdOutDTO>> findMyPosts(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+    public Optional<List<ReadPostByPostIdOutDTO>> findMyPosts(String postTypes, PostSort sort, String query, Long page, Long size, Long srcUserId) {
         List<PostType> postTypeList = Arrays.stream(postTypes.split(","))
                 .map(PostType::valueOf)
                 .toList();
@@ -312,15 +309,12 @@ public class CustomPostRepoImpl implements CustomPostRepo {
 
         }
 
-        if (mark.equals("true"))
-            readPostByPostIdOutDTOList.removeIf(el -> !el.getBookMarked());
-
         return Optional.ofNullable(readPostByPostIdOutDTOList);
     }
 
     @Override
     // 내가 북마크한 작품 목록
-    public Optional<List<ReadPostByPostIdOutDTO>> findMyPostsWithBookMark(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+    public Optional<List<ReadPostByPostIdOutDTO>> findMyPostsWithBookMark(String postTypes, PostSort sort, String query, Long page, Long size, Long srcUserId) {
         List<PostType> postTypeList = Arrays.stream(postTypes.split(","))
                 .map(PostType::valueOf)
                 .toList();
@@ -383,16 +377,13 @@ public class CustomPostRepoImpl implements CustomPostRepo {
             readPostByPostIdOutDTO.setSubscribed(subscribedExpression != null);
         }
 
-        if (mark.equals("true"))
-            readPostByPostIdOutDTOList.removeIf(el -> !el.getBookMarked());
-
         return Optional.ofNullable(readPostByPostIdOutDTOList);
     }
 
 
     @Override
     // 특정 사용자에 대한 작품 목록
-    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithUser(String postTypes, String mark, Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+    public Optional<List<ReadPostByPostIdOutDTO>> findPostsWithUser(String postTypes, Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId) {
         List<PostType> postTypeList = Arrays.stream(postTypes.split(","))
                 .map(PostType::valueOf)
                 .toList();
@@ -460,9 +451,6 @@ public class CustomPostRepoImpl implements CustomPostRepo {
             readPostByPostIdOutDTO.setBookMarked(bookMarkedExpression != null);
             readPostByPostIdOutDTO.setSubscribed(subscribedExpression != null);
         }
-
-        if (mark.equals("true"))
-            readPostByPostIdOutDTOList.removeIf(el -> !el.getBookMarked());
 
         return Optional.ofNullable(readPostByPostIdOutDTOList);
     }

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/PostService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/PostService.java
@@ -10,10 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 public interface PostService {
     CreatePostOutDTO createPost(CreatePostInDTO createPostInDTO, Long srcUserId) throws Exception;
     ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId);
-    ReadPostByPostIdOutDTOs readPostsWithSubs(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId);
-    ReadPostByPostIdOutDTOs readMyPosts(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId);
-    ReadPostByPostIdOutDTOs readMyPostsWithBookMark(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId);
-    ReadPostByPostIdOutDTOs readPostsWithUser(String postTypes, String mark, Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId);
+    ReadPostByPostIdOutDTOs readPostsWithSubs(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId);
+    ReadPostByPostIdOutDTOs readMyPosts(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId);
+    ReadPostByPostIdOutDTOs readMyPostsWithBookMark(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId);
+    ReadPostByPostIdOutDTOs readPostsWithUser(String postTypes,  Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId);
     ReadPostByPostIdOutDTO readPostByPostId(Long postId, Long srcUserId);
     UpdatePostOutDTO updatePost(UpdatePostInDTO updatePostInDTO, Long srcUserId) throws Exception;
     ReadCommentOutDTOs readComment(Long postId, Long page, Long size);

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/PostService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/PostService.java
@@ -10,10 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 public interface PostService {
     CreatePostOutDTO createPost(CreatePostInDTO createPostInDTO, Long srcUserId) throws Exception;
     ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId);
-    ReadPostByPostIdOutDTOs readPostsWithSubs(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId);
-    ReadPostByPostIdOutDTOs readMyPosts(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId);
-    ReadPostByPostIdOutDTOs readMyPostsWithBookMark(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId);
-    ReadPostByPostIdOutDTOs readPostsWithUser(String postTypes,  Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId);
+    ReadPostByPostIdOutDTOs readPostsWithSubs(String postTypes,  PostSort sort, Long page, Long size, Long srcUserId);
+    ReadPostByPostIdOutDTOs readMyPosts(String postTypes,  PostSort sort, Long page, Long size, Long srcUserId);
+    ReadPostByPostIdOutDTOs readMyPostsWithBookMark(String postTypes,  PostSort sort, Long page, Long size, Long srcUserId);
+    ReadPostByPostIdOutDTOs readPostsWithUser(String postTypes,  Long userId, PostSort sort, Long page, Long size, Long srcUserId);
     ReadPostByPostIdOutDTO readPostByPostId(Long postId, Long srcUserId);
     UpdatePostOutDTO updatePost(UpdatePostInDTO updatePostInDTO, Long srcUserId) throws Exception;
     ReadCommentOutDTOs readComment(Long postId, Long page, Long size);

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/PostService.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/PostService.java
@@ -9,7 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface PostService {
     CreatePostOutDTO createPost(CreatePostInDTO createPostInDTO, Long srcUserId) throws Exception;
-    ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId, Long wordId);
+    ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId);
     ReadPostByPostIdOutDTOs readPostsWithSubs(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId);
     ReadPostByPostIdOutDTOs readMyPosts(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId);
     ReadPostByPostIdOutDTOs readMyPostsWithBookMark(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId);

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
@@ -74,8 +74,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId, Long wordId) {
-        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithWord(postTypes, mark, sort, query, page, size, srcUserId, wordId);
+    public ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId) {
+        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithWord(postTypes, sort, page, size, srcUserId, wordId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
 

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
@@ -74,7 +74,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId) {
+    public ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes,PostSort sort, Long page, Long size, Long srcUserId, Long wordId) {
         Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithWord(postTypes, sort, page, size, srcUserId, wordId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
@@ -83,8 +83,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readPostsWithSubs(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId) {
-        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithSubs(postTypes, mark, sort, query, page, size, srcUserId);
+    public ReadPostByPostIdOutDTOs readPostsWithSubs(String postTypes, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithSubs(postTypes, sort, query, page, size, srcUserId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
 
@@ -92,8 +92,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readMyPosts(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId) {
-        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findMyPosts(postTypes, mark, sort, query, page, size, srcUserId);
+    public ReadPostByPostIdOutDTOs readMyPosts(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId) {
+        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findMyPosts(postTypes, sort, query, page, size, srcUserId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
 
@@ -101,8 +101,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readMyPostsWithBookMark(String postTypes, String mark, PostSort sort, String query, Long page, Long size, Long srcUserId) {
-        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findMyPostsWithBookMark(postTypes, mark, sort, query, page, size, srcUserId);
+    public ReadPostByPostIdOutDTOs readMyPostsWithBookMark(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId) {
+        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findMyPostsWithBookMark(postTypes, sort, query, page, size, srcUserId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
 
@@ -110,8 +110,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readPostsWithUser(String postTypes, String mark, Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId) {
-        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithUser(postTypes, mark, userId, sort, query, page, size, srcUserId);
+    public ReadPostByPostIdOutDTOs readPostsWithUser(String postTypes,  Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId) {
+        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithUser(postTypes, userId, sort, query, page, size, srcUserId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
 

--- a/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/service/impl/PostServiceImpl.java
@@ -74,7 +74,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes,PostSort sort, Long page, Long size, Long srcUserId, Long wordId) {
+    public ReadPostByPostIdOutDTOs readPostsWithWord(String postTypes, PostSort sort, Long page, Long size, Long srcUserId, Long wordId) {
         Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithWord(postTypes, sort, page, size, srcUserId, wordId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
@@ -83,8 +83,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readPostsWithSubs(String postTypes, PostSort sort, String query, Long page, Long size, Long srcUserId) {
-        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithSubs(postTypes, sort, query, page, size, srcUserId);
+    public ReadPostByPostIdOutDTOs readPostsWithSubs(String postTypes, PostSort sort, Long page, Long size, Long srcUserId) {
+        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithSubs(postTypes, sort, page, size, srcUserId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
 
@@ -92,8 +92,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readMyPosts(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId) {
-        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findMyPosts(postTypes, sort, query, page, size, srcUserId);
+    public ReadPostByPostIdOutDTOs readMyPosts(String postTypes, PostSort sort, Long page, Long size, Long srcUserId) {
+        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findMyPosts(postTypes, sort, page, size, srcUserId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
 
@@ -101,8 +101,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readMyPostsWithBookMark(String postTypes,  PostSort sort, String query, Long page, Long size, Long srcUserId) {
-        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findMyPostsWithBookMark(postTypes, sort, query, page, size, srcUserId);
+    public ReadPostByPostIdOutDTOs readMyPostsWithBookMark(String postTypes, PostSort sort, Long page, Long size, Long srcUserId) {
+        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findMyPostsWithBookMark(postTypes, sort, page, size, srcUserId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
 
@@ -110,8 +110,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public ReadPostByPostIdOutDTOs readPostsWithUser(String postTypes,  Long userId, PostSort sort, String query, Long page, Long size, Long srcUserId) {
-        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithUser(postTypes, userId, sort, query, page, size, srcUserId);
+    public ReadPostByPostIdOutDTOs readPostsWithUser(String postTypes, Long userId, PostSort sort, Long page, Long size, Long srcUserId) {
+        Optional<List<ReadPostByPostIdOutDTO>> readPostByPostIdOutDTOs = postRepo.findPostsWithUser(postTypes, userId, sort, page, size, srcUserId);
 
         ReadPostByPostIdOutDTOs posts = ReadPostByPostIdOutDTOs.builder().posts(readPostByPostIdOutDTOs.orElse(new ArrayList<>())).build();
 
@@ -165,7 +165,7 @@ public class PostServiceImpl implements PostService {
 
         List<ReadCommentOutDTO> readCommentOutDTOList = postRepo.findCommentAllBy(postId, page, size);
 
-        for(ReadCommentOutDTO readCommentOutDTO : readCommentOutDTOList)
+        for (ReadCommentOutDTO readCommentOutDTO : readCommentOutDTOList)
             comments.getComments().add(readCommentOutDTO);
 
         return comments;

--- a/back/wordseed/src/main/resources/application.yml
+++ b/back/wordseed/src/main/resources/application.yml
@@ -15,4 +15,4 @@ spring:
     pathmatch:
       matching-strategy: ant_path_matcher
 server:
-  port: 8081
+  port: 8080

--- a/back/wordseed/src/main/resources/application.yml
+++ b/back/wordseed/src/main/resources/application.yml
@@ -15,4 +15,4 @@ spring:
     pathmatch:
       matching-strategy: ant_path_matcher
 server:
-  port: 8080
+  port: 8081


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- postService method: query, mark 파라미터 제거

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
#### readPostsWithWord method에서 query, mark 파라미터 삭제 - 6bf0d0949bfd1f9165b304090d278af017092c58
- readPostsWithWord method에서 query, mark 파라미터 삭제
#### readPosts method 5종에 mark 파라미터 삭제 - fbf7437049f065c5de2f2db4d846eeb41fa68a3e
- readPosts method 5종에 mark 파라미터 삭제
#### 포트를 8080으로 변경 - 6d8b31510641ec15769b2af02f24f7d9ae556435
- SpringBook server 포트를 8081에서 8080으로 변경
#### readPosts method 5종 query 파라미터 삭제 - cd776214ce05837a83d4ab53512d1e41c02c54b3
- readPosts method 5종 query 파라미터 삭제
#### 포트를 8080으로 변경 - 13009f311ab885d1fc0729b1f2c5361bd7e1a38f
- SpringBook server 포트를 8081에서 8080으로 변경

## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->
- [X] PostAPI를 이용하여 readPost 5종에 대한 테스트 진행

## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
