### PR TITLE
#187: 작품 목록 페이지 SSR 구현

### DIFF
--- a/front/src/api/feed/get-feed-list.ts
+++ b/front/src/api/feed/get-feed-list.ts
@@ -1,19 +1,30 @@
 import { axios } from "@/lib/axios";
-import { useInfiniteQuery } from "@tanstack/react-query";
-import { FeedListDTO, FeedList } from "./types";
+import {
+  QueryClient,
+  useInfiniteQuery,
+  dehydrate,
+} from "@tanstack/react-query";
 import { InfiniteQueryConfig } from "@/lib/react-query";
+import { FeedListDTO, FeedList } from "./types";
 
 const REQUEST_SIZE = 5;
+export const DEFAULT_POST_TYPE = "TEXT,PAINT,VIDEO,MUSIC";
+export const DEFAULT_SORT = "DATE_DSC";
 
 export async function getFeedList(params: FeedListDTO): Promise<FeedList> {
   return axios.get(`/post/list/word`, { params });
 }
 
 type QueryFnType = typeof getFeedList;
-type UseFeedListOptions = {
+
+interface UseFeedListOptions {
   params: FeedListDTO;
   config?: InfiniteQueryConfig<QueryFnType>;
-};
+}
+
+interface PrefetchUseFeedListOptions extends UseFeedListOptions {
+  queryClient: QueryClient;
+}
 
 export function useFeedList({ params, config }: UseFeedListOptions) {
   return useInfiniteQuery({
@@ -21,7 +32,7 @@ export function useFeedList({ params, config }: UseFeedListOptions) {
     queryKey: ["FeedList", params],
     queryFn: ({ pageParam }) =>
       getFeedList({ ...params, size: REQUEST_SIZE, page: pageParam }),
-    initialPageParam: 1,
+    initialPageParam: 2,
     getNextPageParam: (lastPage, allPages) => {
       const morePagesExist = lastPage?.posts?.length === REQUEST_SIZE;
       if (!morePagesExist) return undefined;
@@ -32,4 +43,25 @@ export function useFeedList({ params, config }: UseFeedListOptions) {
       pages: data.pages.flatMap((page) => page.posts),
     }),
   });
+}
+
+export async function usePrefetchFeedList({
+  queryClient,
+  params,
+  config,
+}: PrefetchUseFeedListOptions) {
+  await queryClient.prefetchInfiniteQuery({
+    ...config,
+    queryKey: ["FeedList", params],
+    queryFn: ({ pageParam }) =>
+      getFeedList({ ...params, size: 5, page: pageParam }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) => {
+      const morePagesExist = lastPage?.posts?.length === 5;
+      if (!morePagesExist) return undefined;
+      return allPages.length + 1;
+    },
+    pages: 1,
+  });
+  return dehydrate(queryClient);
 }

--- a/front/src/api/feed/index.ts
+++ b/front/src/api/feed/index.ts
@@ -1,2 +1,7 @@
 export { getFeedDetail } from "./get-feed-detail";
-export { getFeedList, useFeedList } from "./get-feed-list";
+export {
+  useFeedList,
+  usePrefetchFeedList,
+  DEFAULT_POST_TYPE as DEFAULT_POST_TYPE,
+  DEFAULT_SORT as DEFAULT_SORT,
+} from "./get-feed-list";

--- a/front/src/app/feedlist/[word_id]/feedlist.module.scss
+++ b/front/src/app/feedlist/[word_id]/feedlist.module.scss
@@ -40,27 +40,6 @@
 
 .swiper-card {
   @include flex;
+  height: calc(100vh - 5rem);
   flex-direction: column;
-}
-
-.content-container {
-  width: 100%;
-  flex-grow: 1;
-  height: calc(100% - 8.75rem);
-  padding: 3rem;
-  overflow-y: scroll;
-}
-.content-wrapper {
-  @include flex;
-  flex-direction: column;
-  justify-content: center;
-  width: 100%;
-  min-height: 100%;
-}
-
-.content {
-  @include font($fs: $body1);
-  text-align: center;
-  word-break: normal;
-  width: 100%;
 }

--- a/front/src/app/feedlist/[word_id]/layout.tsx
+++ b/front/src/app/feedlist/[word_id]/layout.tsx
@@ -1,0 +1,37 @@
+import { HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import {
+  usePrefetchFeedList,
+  DEFAULT_POST_TYPE,
+  DEFAULT_SORT,
+} from "@/api/feed/";
+import { FeedListDTO } from "@/api/feed/types";
+
+type FeedLayoutProps = {
+  children: React.ReactNode;
+  params: { word_id: number };
+};
+
+export default async function FeedLayout({
+  children,
+  params,
+}: FeedLayoutProps) {
+  const wordId = params.word_id;
+
+  const queryClient = new QueryClient();
+  const defaultParams: FeedListDTO = {
+    wordId: wordId,
+    postType: DEFAULT_POST_TYPE,
+    sort: DEFAULT_SORT,
+  };
+
+  const dehydratedQueryClient = await usePrefetchFeedList({
+    queryClient: queryClient,
+    params: defaultParams,
+  });
+
+  return (
+    <HydrationBoundary state={dehydratedQueryClient}>
+      {children}
+    </HydrationBoundary>
+  );
+}

--- a/front/src/app/feedlist/[word_id]/page.tsx
+++ b/front/src/app/feedlist/[word_id]/page.tsx
@@ -59,11 +59,6 @@ export default function Feedlist({ params }: FeedlistProps) {
     .filter((type) => type)
     .join(",");
 
-  if (!postType) {
-    alert("하나 이상의 종류를 선택해주세요");
-    postType = "TEXT";
-  }
-
   const feedListParams: FeedListDTO = {
     wordId: wordId,
     postType: postType,

--- a/front/src/app/feedlist/[word_id]/page.tsx
+++ b/front/src/app/feedlist/[word_id]/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { useInView } from "react-intersection-observer";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { FeedContent, FeedInterface, Comment } from "@/components";
 import { useFeedList } from "@/api/feed";
 import useSearchFilterStateStore from "@/stores/search-filter";
 import useCommentToggleStateStore from "@/stores/comment-toggle";
+import { FeedListDTO } from "@/api/feed/types";
 import style from "./feedlist.module.scss";
 
 type FeedlistProps = {
@@ -50,7 +50,7 @@ export default function Feedlist({ params }: FeedlistProps) {
   // 해당 말씨로 작품 조회
   const wordId = params.word_id;
   const { text, paint, video, music, isLatest } = useSearchFilterStateStore();
-  const postType = [
+  let postType = [
     text ? "TEXT" : null,
     paint ? "PAINT" : null,
     video ? "VIDEO" : null,
@@ -59,20 +59,19 @@ export default function Feedlist({ params }: FeedlistProps) {
     .filter((type) => type)
     .join(",");
 
-  const { status, data, fetchNextPage } = useFeedList({
-    params: {
-      wordId: wordId,
-      postType: postType,
-      sort: isLatest ? "DATE_DSC" : "LIKE_DSC",
-    },
-  });
+  if (!postType) {
+    alert("하나 이상의 종류를 선택해주세요");
+    postType = "TEXT";
+  }
 
-  const [ref] = useInView({
-    onChange: (inView) => {
-      if (inView) {
-        fetchNextPage();
-      }
-    },
+  const feedListParams: FeedListDTO = {
+    wordId: wordId,
+    postType: postType,
+    sort: isLatest ? "DATE_DSC" : "LIKE_DSC",
+  };
+
+  const { data, status, fetchNextPage } = useFeedList({
+    params: feedListParams,
   });
 
   const swiperRef = useRef<any>(null);
@@ -207,9 +206,11 @@ export default function Feedlist({ params }: FeedlistProps) {
       hasListenerFirstSlide.current = true;
     }
   };
+
   return (
     <>
-      {status === "success" && (
+      {status === "success" && !data.pages.length && <p>결과 없음</p>}
+      {status === "success" && data.pages.length && (
         <Swiper
           ref={swiperRef}
           className={`${style["swiper-container"]} ${
@@ -225,7 +226,7 @@ export default function Feedlist({ params }: FeedlistProps) {
           longSwipesRatio={0.05}
           onReachEnd={() => fetchNextPage()}
         >
-          {data?.pages.map((feedData) => (
+          {data.pages.map((feedData) => (
             <SwiperSlide key={feedData.postId} className={style["swiper-card"]}>
               <FeedContent feedData={feedData} />
               <FeedInterface feedData={feedData} />

--- a/front/src/stores/search-filter.ts
+++ b/front/src/stores/search-filter.ts
@@ -21,6 +21,13 @@ export const initialState: SearchFilterState = {
   isLatest: true,
 };
 
+const postTypes: (keyof SearchFilterState)[] = [
+  "text",
+  "paint",
+  "video",
+  "music",
+];
+
 const useSearchFilterStateStore = create<
   SearchFilterState & SearchFilterStateStore
 >((set) => ({
@@ -30,7 +37,17 @@ const useSearchFilterStateStore = create<
   music: true,
   isLatest: true,
   setIsActive: (clickedType: keyof SearchFilterState) =>
-    set((state) => ({ [clickedType]: !state[clickedType] })),
+    set((state) => {
+      const otherTypesBoolean: boolean[] = [];
+      postTypes.forEach((type) => {
+        if (type === clickedType) return;
+        otherTypesBoolean.push(state[type]);
+      });
+      if (otherTypesBoolean.every((el) => el === false) && state[clickedType]) {
+        return state;
+      }
+      return { [clickedType]: !state[clickedType] };
+    }),
   clearSearchFilterState: () => set(initialState),
 }));
 


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- 작품 목록 페이지 SSR 구현

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### 무한 스크롤 페이지 SSR hook 구현 - 40334750040c8ae10a099a52004fea9f532c784f
- prefetchInfiniteQuery 사용
### feedlist 페이지 layout에 SSR query hook 장착 - 28d35e7e263ae65f4b7cb33bb0feb9dc42b71a45
- layout 페이지에서 prefetchInfiniteQuery로 데이터 받고 page에 넘겨줌
### feedlist page에서 데이터 사용 - 233d5d7e0d02fc0708ab3fbce851cf453d341ef2
### filter UI 수정 - e68cec9b2a3003682cb43b4942ea0d1f8a9e57df
- API 요청 param 중  postType에 아무것도 없으면 서버 에러 발생
- 네 가지 타입 중 무조건 하나는 선택되어 있도록 수정
- 차후 필터링 아래와 같이 개선할 예정
1. 초기에 버튼은 아무 것도 눌려있지 않은 상태로 모든 타입 렌더링
2. 특정 타입 클릭 시 버튼이 선택되며 해당 타입만 렌더링
3. 네 개의 버튼이 모두 눌려있지 않을 때 모든 타입 렌더링


## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->


## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
