### PR TITLE
#191: postService: readPost 중 subscribe subquery 수정

### DIFF
--- a/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomPostRepoImpl.java
+++ b/back/wordseed/src/main/java/com/spring/wordseed/repo/custom/impl/CustomPostRepoImpl.java
@@ -163,7 +163,7 @@ public class CustomPostRepoImpl implements CustomPostRepo {
                     .select(qFollow)
                     .from(qFollow)
                     .where(qFollow.srcUser.userId.eq(srcUserId))
-                    .where(qFollow.dstUser.userId.eq(readPostByPostIdOutDTO.getPostId()))
+                    .where(qFollow.dstUser.userId.eq(readPostByPostIdOutDTO.getUserId()))
                     .fetchOne();
 
             readPostByPostIdOutDTO.setLiked(likedExpression != null);


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- postService: readPost 중 subscribe subquery 수정

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
#### postService: readPost 중 subscribe subquery 수정 - de5016a15779ce55db5a3faedd772e26638c4967
- readPost:findPostsWithWord 메서드 중 subscribe 여부를 나타는 subquery  조건 중 follow에 postId를 userId로 교체

## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->
- [X] PostAPI 를 이용하여 findPostsWithWord 메서드 테스트 진행

## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
