### PR TITLE
#151: profile post api 연결

### DIFF
--- a/front/src/api/feed/get-feed-api.ts
+++ b/front/src/api/feed/get-feed-api.ts
@@ -1,0 +1,52 @@
+import { axios } from "@/lib/axios";
+import {
+  FeedListDTO,
+  WordFeedListDTO,
+  FeedList,
+  UserFeedListDTO,
+  FeedType,
+  FeedListQueryType,
+} from "./types";
+
+export async function getWordFeedList(
+  params: WordFeedListDTO
+): Promise<FeedList> {
+  return axios.get(`/post/list/word`, { params });
+}
+
+export async function getMyFeedList(params: FeedListDTO): Promise<FeedList> {
+  return axios.get(`/post/list/self`, { params });
+}
+
+export async function getBookmarkFeedList(
+  params: FeedListDTO
+): Promise<FeedList> {
+  return axios.get(`/post/list/book-mark`, { params });
+}
+
+export async function getUserFeedList(
+  params: UserFeedListDTO
+): Promise<FeedList> {
+  return axios.get(`/post/list/user`, { params });
+}
+
+export const feedListQuery: {
+  [K in FeedType]: () => FeedListQueryType<K>;
+} = {
+  word: () => ({
+    queryKey: (params: WordFeedListDTO) => ["wordFeedList", params],
+    queryFn: (params: WordFeedListDTO) => getWordFeedList(params),
+  }),
+  my: () => ({
+    queryKey: (params: FeedListDTO) => ["myFeedList", params],
+    queryFn: (params: FeedListDTO) => getMyFeedList(params),
+  }),
+  bookmark: () => ({
+    queryKey: (params: FeedListDTO) => ["bookmarkFeedList", params],
+    queryFn: (params: FeedListDTO) => getBookmarkFeedList(params),
+  }),
+  user: () => ({
+    queryKey: (params: UserFeedListDTO) => ["userFeedList", params],
+    queryFn: (params: UserFeedListDTO) => getUserFeedList(params),
+  }),
+};

--- a/front/src/api/feed/types.tsx
+++ b/front/src/api/feed/types.tsx
@@ -1,5 +1,12 @@
 export type FeedType = "word" | "my" | "bookmark" | "user";
 
+export enum FeedTypeEnum {
+  Word = "word",
+  My = "my",
+  Bookmark = "bookmark",
+  User = "user",
+}
+
 export type ParamsByType<T extends FeedType> = T extends "word"
   ? WordFeedListDTO
   : T extends "my" | "bookmark"

--- a/front/src/api/feed/types.tsx
+++ b/front/src/api/feed/types.tsx
@@ -1,10 +1,36 @@
-export type FeedListDTO = {
-  wordId: number;
+export type FeedType = "word" | "my" | "bookmark" | "user";
+
+export type ParamsByType<T extends FeedType> = T extends "word"
+  ? WordFeedListDTO
+  : T extends "my" | "bookmark"
+  ? FeedListDTO
+  : T extends "user"
+  ? UserFeedListDTO
+  : never;
+
+export type QueryFnType<T extends FeedType> = (
+  params: ParamsByType<T>
+) => Promise<FeedList>;
+
+export type FeedListQueryType<T extends FeedType> = {
+  queryKey: (params: ParamsByType<T>) => (string | ParamsByType<T>)[];
+  queryFn: QueryFnType<T>;
+};
+
+export interface FeedListDTO {
   postType: string;
   sort: "DATE_ASC" | "DATE_DSC" | "LIKE_ASC" | "LIKE_DSC";
   page?: number;
   size?: number;
-};
+}
+
+export interface WordFeedListDTO extends FeedListDTO {
+  wordId: number;
+}
+
+export interface UserFeedListDTO extends FeedListDTO {
+  userId: number;
+}
 
 export type FeedDetail = {
   postId: number;

--- a/front/src/app/feedlist/[word_id]/layout.tsx
+++ b/front/src/app/feedlist/[word_id]/layout.tsx
@@ -4,7 +4,7 @@ import {
   DEFAULT_POST_TYPE,
   DEFAULT_SORT,
 } from "@/api/feed/";
-import { FeedListDTO } from "@/api/feed/types";
+import { WordFeedListDTO } from "@/api/feed/types";
 
 type FeedLayoutProps = {
   children: React.ReactNode;
@@ -18,7 +18,7 @@ export default async function FeedLayout({
   const wordId = params.word_id;
 
   const queryClient = new QueryClient();
-  const defaultParams: FeedListDTO = {
+  const defaultParams: WordFeedListDTO = {
     wordId: wordId,
     postType: DEFAULT_POST_TYPE,
     sort: DEFAULT_SORT,
@@ -27,6 +27,7 @@ export default async function FeedLayout({
   const dehydratedQueryClient = await usePrefetchFeedList({
     queryClient: queryClient,
     params: defaultParams,
+    type: "word",
   });
 
   return (

--- a/front/src/app/feedlist/[word_id]/page.tsx
+++ b/front/src/app/feedlist/[word_id]/page.tsx
@@ -6,7 +6,7 @@ import { FeedContent, FeedInterface, Comment } from "@/components";
 import { useFeedList } from "@/api/feed";
 import useSearchFilterStateStore from "@/stores/search-filter";
 import useCommentToggleStateStore from "@/stores/comment-toggle";
-import { FeedListDTO } from "@/api/feed/types";
+import { WordFeedListDTO } from "@/api/feed/types";
 import style from "./feedlist.module.scss";
 
 type FeedlistProps = {
@@ -59,7 +59,7 @@ export default function Feedlist({ params }: FeedlistProps) {
     .filter((type) => type)
     .join(",");
 
-  const feedListParams: FeedListDTO = {
+  const feedListParams: WordFeedListDTO = {
     wordId: wordId,
     postType: postType,
     sort: isLatest ? "DATE_DSC" : "LIKE_DSC",
@@ -67,6 +67,7 @@ export default function Feedlist({ params }: FeedlistProps) {
 
   const { data, status, fetchNextPage } = useFeedList({
     params: feedListParams,
+    type: "word",
   });
 
   const swiperRef = useRef<any>(null);

--- a/front/src/app/profile/[user_id]/layout.tsx
+++ b/front/src/app/profile/[user_id]/layout.tsx
@@ -1,24 +1,40 @@
 import { userInfoQuery } from "@/api/user/get-user-api";
-import {
-  HydrationBoundary,
-  QueryClient,
-  dehydrate,
-} from "@tanstack/react-query";
+import { usePrefetchFeedList } from "@/api/feed/";
+import { HydrationBoundary, QueryClient } from "@tanstack/react-query";
+import { UserFeedListDTO, FeedTypeEnum } from "@/api/feed/types";
+import { myParams } from "@/constants/feed-default";
+
+type ProfileLayoutProps = {
+  children: React.ReactNode;
+  params: { user_id: number };
+};
 
 export default async function DashboardLayout({
   children,
   params,
-}: {
-  children: React.ReactNode;
-  params: { user_id: number };
-}) {
-  const userId = Number(params.user_id);
-  const { queryKey, queryFn } = userInfoQuery.userInfo(userId);
+}: ProfileLayoutProps) {
   const queryClient = new QueryClient();
-  await queryClient.prefetchQuery({ queryKey, queryFn });
+
+  const myId = 4;
+  const userId = Number(params.user_id);
+  const isMe = myId === userId;
+
+  const userParams: UserFeedListDTO = {
+    ...myParams,
+    userId,
+  };
+  const props = {
+    queryClient: queryClient,
+    params: isMe ? myParams : userParams,
+    type: isMe ? FeedTypeEnum.My : FeedTypeEnum.User,
+  };
+
+  await queryClient.prefetchQuery(userInfoQuery.userInfo(userId));
+
+  const dehydratedQueryClient = await usePrefetchFeedList(props);
 
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
+    <HydrationBoundary state={dehydratedQueryClient}>
       {children}
     </HydrationBoundary>
   );

--- a/front/src/app/profile/[user_id]/layout.tsx
+++ b/front/src/app/profile/[user_id]/layout.tsx
@@ -23,6 +23,7 @@ export default async function DashboardLayout({
     ...myParams,
     userId,
   };
+
   const props = {
     queryClient: queryClient,
     params: isMe ? myParams : userParams,

--- a/front/src/app/profile/[user_id]/page.tsx
+++ b/front/src/app/profile/[user_id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import styles from "./profile.module.scss";
 import { useInView } from "react-intersection-observer";
 import useFilterButtonHiddenStateStore from "@/stores/profile-filter";
 import { ContentCardList } from "@/components";
@@ -22,10 +23,10 @@ export default function Profile({ params }: ProfileProps) {
   const userId = Number(params.user_id);
 
   return (
-    <>
+    <div className={styles.container}>
       <Header userId={userId} />
       <ProfileCategory categoryRef={ref} params={params} />
       <ContentCardList />
-    </>
+    </div>
   );
 }

--- a/front/src/app/profile/[user_id]/page.tsx
+++ b/front/src/app/profile/[user_id]/page.tsx
@@ -26,7 +26,7 @@ export default function Profile({ params }: ProfileProps) {
     <div className={styles.container}>
       <Header userId={userId} />
       <ProfileCategory categoryRef={ref} params={params} />
-      <ContentCardList />
+      <ContentCardList userId={userId} />
     </div>
   );
 }

--- a/front/src/app/profile/[user_id]/profile.module.scss
+++ b/front/src/app/profile/[user_id]/profile.module.scss
@@ -1,0 +1,5 @@
+.container {
+  height: calc(100dvh - 5rem);
+  overflow: auto;
+  padding-bottom: 2rem;
+}

--- a/front/src/app/profile/_component/ProfileCategory/ProfileCategory.tsx
+++ b/front/src/app/profile/_component/ProfileCategory/ProfileCategory.tsx
@@ -11,11 +11,12 @@ export default function ProfileCategory({
   params,
   categoryRef,
 }: ProfileCategoryProps) {
-  const myId = 1;
+  const myId = 4;
+  const userId = Number(params.user_id);
 
   return (
     <div className={styles.wrapper} ref={categoryRef}>
-      {myId === params.user_id && (
+      {myId === userId && (
         <ToggleButton type="wide" toggleA="내 작품" toggleB="북마크" />
       )}
       <Filter />

--- a/front/src/components/ContentCard/ContentCard.module.scss
+++ b/front/src/components/ContentCard/ContentCard.module.scss
@@ -9,8 +9,9 @@
   justify-content: center;
   align-items: center;
   padding: 2rem;
+  width: 100%;
 
-  min-height: 20rem;
+  min-height: 30rem;
 }
 
 .media {
@@ -44,21 +45,34 @@
 .wrapper {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
+  width: 100%;
+  min-height: 24rem;
   gap: 1rem;
+}
+
+.text-section {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  width: 100%;
 }
 
 .title {
   @include font($body1, $bold, $black, $noto-serif);
+  width: 100%;
+
+  text-align: center;
 }
 
 .content {
   @include font($body2, $regular, $black, $noto-serif);
   white-space: pre-line;
+  width: 100%;
 }
 
-.start {
+.left {
   text-align: left;
 }
 
@@ -66,10 +80,13 @@
   text-align: center;
 }
 
-.end {
+.right {
   text-align: right;
 }
 
 .artist {
   @include font($body2, $regular, $black, $noto-sans);
+  width: 100%;
+  text-align: center;
+  margin-bottom: 1rem;
 }

--- a/front/src/components/ContentCard/ContentCard.module.scss
+++ b/front/src/components/ContentCard/ContentCard.module.scss
@@ -59,7 +59,7 @@
 }
 
 .start {
-  text-align: start;
+  text-align: left;
 }
 
 .center {
@@ -67,7 +67,7 @@
 }
 
 .end {
-  text-align: end;
+  text-align: right;
 }
 
 .artist {

--- a/front/src/components/ContentCard/ContentCard.module.scss
+++ b/front/src/components/ContentCard/ContentCard.module.scss
@@ -20,7 +20,7 @@
   // 이미지 크기임시 값
   width: 100%;
   height: 0;
-  padding-bottom: 125%;
+  padding-bottom: 75%;
 
   img {
     object-fit: cover;
@@ -31,6 +31,7 @@
 
   video {
     max-height: 50rem;
+    object-fit: cover;
     width: 100%;
   }
 

--- a/front/src/components/ContentCard/ContentCard.tsx
+++ b/front/src/components/ContentCard/ContentCard.tsx
@@ -1,31 +1,24 @@
 "use client";
 
+import { FeedDetail } from "@/api/feed/types";
 import styles from "./ContentCard.module.scss";
 import Image from "next/image";
 import Link from "next/link";
 import { useRef } from "react";
 import { useInView } from "react-intersection-observer";
 
-interface ContentCardProps {
-  postId: number;
-  type: "text" | "img" | "video" | "sound";
-  title: string;
-  content: string;
-  textAlign: "start" | "center" | "end";
-  userName: string;
-  url: string;
-}
-
 export default function ContentCard({
   postId,
-  type,
-  title,
+  postType,
+  postAlign,
+  word,
   content,
-  textAlign,
   userName,
   url,
-}: ContentCardProps) {
-  const contentClassName = `${styles.content} ${styles[textAlign]}`;
+}: FeedDetail) {
+  const contentClassName = `${styles.content} ${
+    styles[postAlign.toLowerCase()]
+  }`;
   const videoRef = useRef<HTMLVideoElement>(null);
   const [ref] = useInView({
     threshold: 0.8,
@@ -41,18 +34,18 @@ export default function ContentCard({
 
   return (
     <Link className={styles.link} href={`/feed/${postId}`} ref={ref}>
-      {type === "text" ? (
+      {postType === "TEXT" ? (
         <main className={styles.container}>
           <div className={styles.wrapper}>
-            <p className={styles.title}>{title}</p>
+            <p className={styles.title}>{word}</p>
             <p className={contentClassName}>{content}</p>
             <p className={styles.artist}>{userName}</p>
           </div>
         </main>
       ) : (
         <main className={styles.media}>
-          {type === "img" && <Image src={url} alt="12" fill />}
-          {type === "video" && (
+          {postType === "PAINT" && <Image src={url} alt="12" fill />}
+          {postType === "VIDEO" && (
             <video
               ref={videoRef}
               muted
@@ -63,7 +56,7 @@ export default function ContentCard({
               src={url}
             ></video>
           )}
-          {type === "sound" && <audio src={url} controls />}
+          {postType === "MUSIC" && <audio src={url} controls />}
         </main>
       )}
     </Link>

--- a/front/src/components/ContentCard/ContentCard.tsx
+++ b/front/src/components/ContentCard/ContentCard.tsx
@@ -3,7 +3,7 @@
 import styles from "./ContentCard.module.scss";
 import Image from "next/image";
 import Link from "next/link";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { useInView } from "react-intersection-observer";
 
 interface ContentCardProps {

--- a/front/src/components/ContentCard/ContentCard.tsx
+++ b/front/src/components/ContentCard/ContentCard.tsx
@@ -37,8 +37,10 @@ export default function ContentCard({
       {postType === "TEXT" ? (
         <main className={styles.container}>
           <div className={styles.wrapper}>
-            <p className={styles.title}>{word}</p>
-            <p className={contentClassName}>{content}</p>
+            <div className={styles["text-section"]}>
+              <p className={styles.title}>{word}</p>
+              <p className={contentClassName}>{content}</p>
+            </div>
             <p className={styles.artist}>{userName}</p>
           </div>
         </main>

--- a/front/src/components/ContentCardList/ContentCardList.tsx
+++ b/front/src/components/ContentCardList/ContentCardList.tsx
@@ -1,3 +1,4 @@
+import useSearchFilterStateStore from "@/stores/search-filter";
 import { ContentCard } from "..";
 import styles from "./ContentCardList.module.scss";
 
@@ -50,7 +51,17 @@ const datas: ContentCardProps[] = [
   },
 ];
 
-export default function ContentCardList() {
+export default function ContentCardList({ userId }: { userId: number }) {
+  const { text, paint, video, music, isLatest } = useSearchFilterStateStore();
+  let postType = [
+    text ? "TEXT" : null,
+    paint ? "PAINT" : null,
+    video ? "VIDEO" : null,
+    music ? "MUSIC" : null,
+  ]
+    .filter((type) => type)
+    .join(",");
+
   return (
     <div className={styles.container}>
       {datas.map((data) => (

--- a/front/src/components/ContentCardList/ContentCardList.tsx
+++ b/front/src/components/ContentCardList/ContentCardList.tsx
@@ -1,6 +1,9 @@
 import useSearchFilterStateStore from "@/stores/search-filter";
 import { ContentCard } from "..";
 import styles from "./ContentCardList.module.scss";
+import { FeedListDTO, FeedTypeEnum, UserFeedListDTO } from "@/api/feed/types";
+import profileToggleStore from "@/stores/profile-toggle";
+import { useFeedList } from "@/api/feed";
 
 interface ContentCardProps {
   postId: number;
@@ -52,6 +55,10 @@ const datas: ContentCardProps[] = [
 ];
 
 export default function ContentCardList({ userId }: { userId: number }) {
+  const myId = 4;
+  const isMe = myId === userId;
+
+  const { selected } = profileToggleStore();
   const { text, paint, video, music, isLatest } = useSearchFilterStateStore();
   let postType = [
     text ? "TEXT" : null,
@@ -62,11 +69,37 @@ export default function ContentCardList({ userId }: { userId: number }) {
     .filter((type) => type)
     .join(",");
 
+  const feedListParams: FeedListDTO = {
+    postType: postType,
+    sort: isLatest ? "DATE_DSC" : "LIKE_DSC",
+  };
+
+  const userFeedListParams: UserFeedListDTO = {
+    ...feedListParams,
+    userId,
+  };
+
+  const props = {
+    params: isMe ? feedListParams : userFeedListParams,
+    type: isMe
+      ? selected
+        ? FeedTypeEnum.Bookmark
+        : FeedTypeEnum.My
+      : FeedTypeEnum.User,
+  };
+
+  const { data, status, fetchNextPage } = useFeedList(props);
+
   return (
-    <div className={styles.container}>
-      {datas.map((data) => (
-        <ContentCard key={data.postId} {...data} />
-      ))}
-    </div>
+    <>
+      {status === "success" && !data.pages.length && <p>결과 없음</p>}
+      {status === "success" && data.pages.length && (
+        <div className={styles.container}>
+          {data.pages.map((feedData) => (
+            <ContentCard key={feedData.postId} {...feedData} />
+          ))}
+        </div>
+      )}
+    </>
   );
 }

--- a/front/src/constants/feed-default.ts
+++ b/front/src/constants/feed-default.ts
@@ -1,0 +1,7 @@
+import { DEFAULT_POST_TYPE, DEFAULT_SORT } from "@/api/feed";
+import { FeedListDTO } from "@/api/feed/types";
+
+export const myParams: FeedListDTO = {
+  postType: DEFAULT_POST_TYPE,
+  sort: DEFAULT_SORT,
+};


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [X] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- profile feed api 연결

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### refactor: 수정 - 프로필 작품 리스트 CSS 수정 - cc91a36 / 0a22eac
- 작품 타입이 이미지일 경우의 css 수정
- 작품 리스트에 overflow: auto 적용

### refactor: 수정 - feed api 타입 확장 - 992af4b
- 기존 사용하던  useFeed 훅을 확장하여 여러 타입의 피드리스트에서 사용할 수 있도록 타입 확장

### feat: 구현 - profile Layout에 useFeedList 프리패치 데이터 추가 - d7499f0
- 프로필 레이아웃에 프리패치 데이터 HydrateBoundury로 적용

### feat: 구현 - profile feed api 연결 - 796300c
- profile feed api 초기 데이터 ssr로 연결

## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->


## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
