### PR TITLE
#227: feedlist 페이지 Swiper 사용 로직 변경

### DIFF
--- a/front/src/app/feedlist/[[...word_id]]/_component/swiper-component.tsx
+++ b/front/src/app/feedlist/[[...word_id]]/_component/swiper-component.tsx
@@ -1,12 +1,19 @@
 "use client";
-
 import { useRef, useEffect, useState } from "react";
-import { Swiper, SwiperSlide } from "swiper/react";
+import { Swiper, SwiperSlide, SwiperProps } from "swiper/react";
+import { Virtual } from "swiper/modules";
 import useCommentToggleStateStore from "@/stores/comment-toggle";
 import { FeedContent, FeedInterface, Comment } from "@/components";
 import NoData from "./noData";
 import { FeedListData, FeedListFetchNextPage } from "./types";
-import { addListener, removeListener } from "./utils/listener-util";
+import {
+  handleTouchContent,
+  handleTouchInterface,
+  addListener,
+} from "./utils/listener-util";
+
+import "swiper/css";
+import "swiper/css/virtual";
 import style from "./feedlist.module.scss";
 
 type SwiperComponentProps = {
@@ -22,168 +29,104 @@ export default function SwiperComponent({
 }: SwiperComponentProps) {
   const [swiper, setSwiper] = useState<any>(null);
   const { commentToggle } = useCommentToggleStateStore();
-  const touchStartY = useRef<number | null>(null);
-  const hasListenerFirstSlide = useRef<boolean>(false);
   const [activeContentIdx, setActiveContentIdx] = useState<number | null>(null);
+  const touchStartY = useRef<number | null>(null);
+  const [hasFirstSlideListener, setHasFirstSlideListener] =
+    useState<boolean>(false);
+  const [hasSecondSlideListener, setHasSecondSlideListener] =
+    useState<boolean>(false);
 
-  const activeContentRef = useRef<HTMLDivElement>(null);
-  const activeInterfaceRef = useRef<HTMLDivElement>(null);
+  const SwiperOpts: SwiperProps = {
+    modules: [Virtual],
+    virtual: true,
+    direction: "vertical",
+    longSwipesRatio: 0.05,
+    preventInteractionOnTransition: true,
+    lazyPreloadPrevNext: 1,
+    onInit: (swiper) => {
+      setSwiper(swiper);
+      setActiveContentIdx(swiper.activeIndex);
+    },
+    onTransitionEnd: (swiper) => setActiveContentIdx(swiper.activeIndex),
+    onActiveIndexChange: (swiper) => {
+      swiper.slides.forEach((slide) => {
+        if (!slide.firstChild) return;
+        const contentDiv = slide.firstChild as HTMLElement;
+        contentDiv.scrollTop = 0;
+      });
+    },
+    onReachEnd: () => {
+      if (data?.pages.length === 1) return;
+      fetchNextPage();
+    },
+  };
+
+  // swiperKey가 달라져서 새로운 swiper가 생성되어
+  // 새롭게 리스너를 장착해야 하는 경우
+  //  첫번째와 두번째 가상 슬라이드의 리스너 장착 여부를 false로 설정
+  useEffect(() => {
+    if (swiper && hasFirstSlideListener) {
+      setHasFirstSlideListener(false);
+      setHasSecondSlideListener(false);
+    }
+  }, [swiperKey]);
 
   useEffect(() => {
-    if (swiper && !swiper.destroyed && activeContentRef.current) {
-      if (swiper.previousIndex !== undefined) {
-        const prevIndex = swiper.previousIndex;
-        const prevSlide = swiper.slides[prevIndex];
-        const prevContent = prevSlide.firstChild;
-        prevContent.scrollTop = 0;
-      }
-
-      const touchInterface = (e: React.TouchEvent) => {
-        // 터치 시작 y좌표 저장
-        if (e.type === "touchstart") {
-          touchStartY.current = e.touches[0].clientY;
-          return;
-        }
-
-        // 터치가 끝났을 때, 시작점 좌표와 비교해서 방향을 계산 후 슬라이드 이동
-        if (e.type === "touchend" && touchStartY.current) {
-          const touchEndY = e.changedTouches[0].clientY;
-          const scrollUp = touchStartY.current - touchEndY;
-          // 아이콘 터치할 수 있을 정도의 움직임은 무시
-          if (Math.abs(scrollUp) <= 5) return;
-
-          // 이동 전에 이벤트 리스터 모두 제거
-          removeListener({
-            activeContentRef,
-            activeInterfaceRef,
-            touchContent,
-            touchInterface,
-          });
-
-          swiper.allowTouchMove = true;
-          if (scrollUp < -5) swiper.slidePrev(300);
-          else if (scrollUp > 5) swiper.slideNext(300);
-        }
-      };
-
-      const touchContent = (e: React.TouchEvent) => {
-        if (!activeContentRef.current) return;
-        const activeContent = activeContentRef.current;
-        // 현재 content 스크롤 가능한 높이
-        const diff = activeContent.scrollHeight - activeContent.clientHeight;
-        // touchStart 이벤트면 터치한 y좌표를 useRef에 저장
-        if (e.type === "touchstart") {
-          touchStartY.current = e.touches[0].clientY;
-          return;
-        }
-
-        if (e.type === "touchend" && touchStartY.current) {
-          const touchEndY = e.changedTouches[0].clientY;
-          const scrollUp = touchStartY.current - touchEndY < 0;
-          if (activeContentIdx === 0 && scrollUp) {
-            swiper.allowTouchMove = false;
-            addListener({
-              activeContentRef,
-              activeInterfaceRef,
-              touchContent,
-              touchInterface,
-            });
-          }
-          return;
-        }
-
-        // touchMove 이벤트면 현재 touch의 y좌표를 추적하고
-        if (e.type === "touchmove" && touchStartY.current) {
-          const touchMoveY = e.changedTouches[0].clientY;
-
-          // 이를 터치 시작 y좌표와 비교해서 스크롤을 어디로 했는지 확인
-          const scrollUp = touchStartY.current - touchMoveY < 0;
-          const scrollTop = activeContent.scrollTop;
-          // 만약 스크롤을 위로 올리는 상황 & 현재 스크롤의 위치가 최상단 이상이면
-          if (scrollUp && scrollTop <= 0) {
-            // 슬라이드를 위한 터치 감지를 켠다
-            swiper.allowTouchMove = true;
-            // 이벤트 리스너를 지운다
-            removeListener({
-              activeContentRef,
-              activeInterfaceRef,
-              touchContent,
-              touchInterface,
-            });
-            return;
-          }
-          // 스크롤을 아래로 내리는 상황
-          if (!scrollUp && scrollTop >= diff) {
-            swiper.allowTouchMove = true;
-            removeListener({
-              activeContentRef,
-              activeInterfaceRef,
-              touchContent,
-              touchInterface,
-            });
-            return;
-          }
-        }
-      };
-      swiper.allowTouchMove = false;
-      if (data?.pages.length !== 1) {
+    if (swiper && !swiper.destroyed) {
+      // 첫번째나 두번째 가상 슬라이드에 리스너가 장착되어 있지 않은 경우
+      if (
+        (activeContentIdx === 0 && !hasFirstSlideListener) ||
+        (activeContentIdx === 1 && !hasSecondSlideListener)
+      ) {
+        // 현재 보여지는 슬라이드
+        const activeSlide = swiper.visibleSlides[0];
+        const [activeContent, activeInterface] = activeSlide.children;
+        // 리스너 장착
         addListener({
-          activeContentRef,
-          activeInterfaceRef,
-          touchContent,
-          touchInterface,
+          swiper,
+          touchStartY,
+          activeContent,
+          activeInterface,
+          handleTouchContent,
+          handleTouchInterface,
         });
-      }
-      if (activeContentIdx === 0 && !hasListenerFirstSlide.current) {
-        const activeSlide = swiper.slides[activeContentIdx];
-        const activeContent = activeSlide.firstChild;
-        activeContent.addEventListener("touchend", touchContent, {
-          passive: true,
-        });
-        hasListenerFirstSlide.current = true;
+        // 해당 슬라이드 리스너 장착 여부 true로 설정
+        activeContentIdx === 0
+          ? setHasFirstSlideListener(true)
+          : setHasSecondSlideListener(true);
       }
     }
-  });
+    // activeIndex와 리스너 장착 여부를 감지
+  }, [activeContentIdx, hasFirstSlideListener, hasSecondSlideListener]);
 
   return (
     <>
       {!data?.pages.length && <NoData />}
       {!!data?.pages.length && (
-        <Swiper
-          // key를 설정하면 key가 달라질 때 이 컴포넌트가 새롭게 생성됨
-          // 따라서 swiperKey으로 key를 설정해서 swiperKey이 달라질 때만 컴포넌트를 새롭게 생성하고
-          // 데이터가 추가되는 경우는 유지하도록 함
-          key={swiperKey}
-          className={`${style["swiper-container"]}`}
-          direction={"vertical"}
-          onInit={(swiper) => {
-            setSwiper(swiper);
-            setActiveContentIdx(swiper.activeIndex);
-          }}
-          onTransitionStart={(swiper) =>
-            setActiveContentIdx(swiper.activeIndex)
-          }
-          preventInteractionOnTransition={true}
-          longSwipesRatio={0.05}
-          onReachEnd={() => {
-            if (data?.pages.length === 1) return;
-            fetchNextPage();
-          }}
-        >
-          {data?.pages.map((feedData, idx) => (
-            <SwiperSlide key={idx} className={style["swiper-card"]}>
-              <FeedContent
-                activeContentRef={activeContentRef}
-                feedData={feedData}
-              />
-              <FeedInterface
-                activeInterfaceRef={activeInterfaceRef}
-                feedData={feedData}
-              />
-            </SwiperSlide>
-          ))}
+        // key를 설정하면 key가 달라질 때 이 컴포넌트가 새롭게 생성됨
+        // 따라서 swiperKey으로 key를 설정해서 swiperKey이 달라질 때만 컴포넌트를 새롭게 생성하고
+        // 데이터가 추가되는 경우는 유지하도록 함
+        <>
+          <Swiper
+            key={swiperKey}
+            className={`${style["swiper-container"]}`}
+            {...SwiperOpts}
+          >
+            {data?.pages.map((feedData, idx) => (
+              <SwiperSlide
+                key={idx}
+                virtualIndex={idx}
+                className={style["swiper-card"]}
+              >
+                <>
+                  <FeedContent feedData={feedData} />
+                  <FeedInterface feedData={feedData} />
+                </>
+              </SwiperSlide>
+            ))}
+          </Swiper>
           {commentToggle && <Comment />}
-        </Swiper>
+        </>
       )}
     </>
   );

--- a/front/src/app/feedlist/[[...word_id]]/_component/types.ts
+++ b/front/src/app/feedlist/[[...word_id]]/_component/types.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject } from "react";
+import { MutableRefObject, TouchEvent } from "react";
 import {
   FetchNextPageOptions,
   InfiniteQueryObserverResult,
@@ -25,10 +25,19 @@ export type FeedListFetchNextPage = (
   >
 >;
 
-export type ListenerProps = {
-  activeContentRef: MutableRefObject<HTMLDivElement | null>;
-  activeInterfaceRef: MutableRefObject<HTMLDivElement | null>;
-  // any... :(
-  touchContent: any;
-  touchInterface: any;
-};
+interface HandleTouchParams {
+  swiper: any;
+  touchStartY: MutableRefObject<number | null>;
+}
+
+export type HandleTouch = ({
+  swiper,
+  touchStartY,
+}: HandleTouchParams) => (e: TouchEvent) => void;
+
+export interface ListenerProps extends HandleTouchParams {
+  activeContent: HTMLDivElement;
+  activeInterface: HTMLDivElement;
+  handleTouchContent: HandleTouch;
+  handleTouchInterface: HandleTouch;
+}

--- a/front/src/app/feedlist/[[...word_id]]/_component/utils/listener-util.ts
+++ b/front/src/app/feedlist/[[...word_id]]/_component/utils/listener-util.ts
@@ -1,36 +1,93 @@
-import { ListenerProps } from "../types";
+import { HandleTouch, ListenerProps } from "../types";
+
+export const handleTouchContent: HandleTouch =
+  ({ swiper, touchStartY }) =>
+  (e) => {
+    // 현재 view에 보여지고 있는 슬라이드의 content Div 특정
+    const activeSlide = swiper.visibleSlides[0];
+    const activeContent = activeSlide.firstChild;
+
+    if (e.type === "touchstart") {
+      // 터치 시작점 저장
+      touchStartY.current = e.touches[0].clientY;
+      // 현재 스크롤 위치
+      const scrollTop = activeContent.scrollTop;
+      // 스크롤 가능 길이
+      const scrollRange =
+        activeContent.scrollHeight - activeContent.clientHeight;
+      // 스크롤 최상단이거나 최하단일 경우 swiper touch 감지 on
+      if (scrollTop <= 0 || scrollRange <= scrollTop)
+        swiper.allowTouchMove = true;
+    }
+
+    // touchMove 이벤트는 swiper touch 감지가 켜져있을 때(스크롤 최상단 || 최하단)만 처리
+    else if (
+      swiper.allowTouchMove &&
+      e.type === "touchmove" &&
+      touchStartY.current
+    ) {
+      // 현재 content 스크롤 가능한 높이
+      const scrollRange =
+        activeContent.scrollHeight - activeContent.clientHeight;
+      // 스크롤이 없으면 슬라이드 이동으로 마무리
+      if (scrollRange === 0) return;
+
+      // 현재 touch 위치
+      const touchMoveY = e.changedTouches[0].clientY;
+      // touchMoveY와 터치 시작 y좌표를 비교해서 터치 방향 확인
+      const scrollUp = touchStartY.current - touchMoveY < 0;
+      // 현재 스크롤 위치
+      const scrollTop = activeContent.scrollTop;
+      // 내부 스크롤 작동 = (스크롤 최상단 && 아래로 터치) || (스크롤 최하단 && 위로 터치)
+      const scrollToInside =
+        (scrollTop <= 0 && !scrollUp) || (scrollRange <= scrollTop && scrollUp);
+      // 내부 스크롤 작동 경우이면 swiper touch 감지 off
+      if (scrollToInside) swiper.allowTouchMove = false;
+    }
+  };
+
+export const handleTouchInterface: HandleTouch =
+  ({ swiper, touchStartY }) =>
+  (e) => {
+    if (e.type === "touchstart") {
+      // swiper touch 감지 off
+      swiper.allowTouchMove = false;
+      // 터치 시작 y좌표 저장
+      touchStartY.current = e.touches[0].clientY;
+    }
+
+    // touch start와 end의 좌표를 비교해서 터치 방향을 계산 후 슬라이드 이동
+    else if (e.type === "touchend" && touchStartY.current) {
+      // swiper touch 감지 on
+      swiper.allowTouchMove = true;
+      const touchEndY = e.changedTouches[0].clientY;
+      const scrollUp = touchStartY.current - touchEndY;
+      // 아이콘 터치를 위해 scrollUp의 절대값 5 이상인 경우에만 이동
+      if (scrollUp < -5) swiper.slidePrev(300);
+      else if (scrollUp > 5) swiper.slideNext(300);
+    }
+  };
 
 export const addListener = ({
-  activeContentRef,
-  activeInterfaceRef,
-  touchContent,
-  touchInterface,
+  swiper,
+  touchStartY,
+  activeContent,
+  activeInterface,
+  handleTouchContent,
+  handleTouchInterface,
 }: ListenerProps) => {
-  activeContentRef.current?.addEventListener("touchstart", touchContent, {
+  const contentHandler = handleTouchContent({ swiper, touchStartY }) as any;
+  const interfaceHandler = handleTouchInterface({ swiper, touchStartY }) as any;
+  activeContent?.addEventListener("touchstart", contentHandler, {
     passive: true,
   });
-  activeContentRef.current?.addEventListener("touchmove", touchContent, {
+  activeContent?.addEventListener("touchmove", contentHandler, {
     passive: true,
   });
-  activeInterfaceRef.current?.addEventListener("touchstart", touchInterface, {
+  activeInterface?.addEventListener("touchstart", interfaceHandler, {
     passive: true,
   });
-  activeInterfaceRef.current?.addEventListener("touchmove", touchInterface, {
+  activeInterface?.addEventListener("touchend", interfaceHandler, {
     passive: true,
   });
-  activeInterfaceRef.current?.addEventListener("touchend", touchInterface, {
-    passive: true,
-  });
-};
-export const removeListener = ({
-  activeContentRef,
-  activeInterfaceRef,
-  touchContent,
-  touchInterface,
-}: ListenerProps) => {
-  activeContentRef.current?.removeEventListener("touchstart", touchContent);
-  activeContentRef.current?.removeEventListener("touchmove", touchContent);
-  activeInterfaceRef.current?.removeEventListener("touchstart", touchInterface);
-  activeInterfaceRef.current?.removeEventListener("touchmove", touchInterface);
-  activeInterfaceRef.current?.removeEventListener("touchend", touchInterface);
 };

--- a/front/src/components/Navbar/navbar.module.scss
+++ b/front/src/components/Navbar/navbar.module.scss
@@ -8,7 +8,7 @@
   height: 5rem;
   padding: 1rem 1.5rem;
   background-color: $white;
-  z-index: 1;
+  z-index: 2;
   touch-action: none;
 }
 

--- a/front/src/components/comment/comment.module.scss
+++ b/front/src/components/comment/comment.module.scss
@@ -7,7 +7,7 @@
   height: 100%;
   overflow: hidden;
   background-color: $white;
-  z-index: 2;
+  z-index: 3;
   .close {
     @include flex;
     justify-content: flex-end;

--- a/front/src/components/feed-interface/feed-interface.tsx
+++ b/front/src/components/feed-interface/feed-interface.tsx
@@ -1,27 +1,17 @@
-"use client";
-
-import React, { MutableRefObject } from "react";
-import { useSwiper, useSwiperSlide } from "swiper/react";
 import FeedInterfaceTop from "./feed-interface-top";
 import FeedInterfaceBottom from "./feed-interface-bottom";
 import { FeedDetail } from "@/api/feed/types";
 import styles from "./feed-interface.module.scss";
 
 type FeedInterfaceProps = {
-  activeInterfaceRef?: MutableRefObject<HTMLDivElement | null>;
   feedData: FeedDetail;
 };
-function FeedInterface({ activeInterfaceRef, feedData }: FeedInterfaceProps) {
-  const slide = useSwiperSlide();
+
+export default function FeedInterface({ feedData }: FeedInterfaceProps) {
   return (
-    <div
-      ref={activeInterfaceRef && slide.isActive ? activeInterfaceRef : null}
-      className={styles["feed-interface-container"]}
-    >
+    <div className={styles["feed-interface-container"]}>
       <FeedInterfaceTop createdAt={feedData.createdAt} />
       <FeedInterfaceBottom feedData={feedData} />
     </div>
   );
 }
-
-export default React.memo(FeedInterface);

--- a/front/src/components/feed/feed.tsx
+++ b/front/src/components/feed/feed.tsx
@@ -1,27 +1,21 @@
-"use client";
-
-import React, { MutableRefObject } from "react";
-import { useSwiper, useSwiperSlide } from "swiper/react";
 import { FeedDetail } from "@/api/feed/types";
 import style from "./feed.module.scss";
 
 type FeedContentProps = {
-  activeContentRef?: MutableRefObject<HTMLDivElement | null>;
   feedData: FeedDetail;
 };
 
-function FeedContent({ activeContentRef, feedData }: FeedContentProps) {
-  const slide = useSwiperSlide();
+export default function FeedContent({ feedData }: FeedContentProps) {
   return (
-    <div
-      ref={activeContentRef && slide.isActive ? activeContentRef : null}
-      className={style["content-container"]}
-    >
+    <div className={style["content-container"]}>
       <div className={style["content-wrapper"]}>
-        <div className={style["content"]}>{feedData.content}</div>
+        <div className={style["content"]}>
+          {
+            "feedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.content"
+          }
+        </div>
+        {/* <div className={style["content"]}>{feedData.content}</div> */}
       </div>
     </div>
   );
 }
-
-export default React.memo(FeedContent);


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- Swiper 리팩토링

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### Swiper virtual slide 사용과 이에 따른 EventListener 함수 수정  - 3f71d2057019f00b38e242b4ab2d8c94757246f8, c2c78b4fa511b8ea8ddaa9bc6ddcc400b8cab3f1
**1. DOM**
- before
  - fetching한 모든 feed들을 담은 각각의 슬라이드를 모두 DOM에 누적했었음
  - 이 조건에서 성능을 높이기 위해 useMemo로 각 슬라이드의 내부 컴포넌트들을 캐싱했었음
- after
  - 이전 슬라이드, 현재 슬라이드, 다음 슬라이드만 DOM에 존재함
  - 가상 슬라이드 이동 시, 물리적으로 슬라이드가 넘어가는 것이 아니라 slide가 넘어가는 animation만 연출하고 존재하는 세 슬라이드의 내용만 바뀜
  - 슬라이드의 양이 최대 3개뿐이라 useMemo 제거
- 이점
  - DOM에 최대 3개의 slide만 존재하기 때문에 메모리 효율성과 스크롤 및 브라우저 성능 최적화 가능

**2. EventListener 탈부착**
 - before
   - feedcontent 내부 스크롤 작동을 위해 active slide가 바뀔 때마다 touch event listener를 장착 및 제거를 반복했음
 - after
   - 가상 슬라이드에서 slide의 DOM element는 재사용되기 때문에 초기에 첫번째와 두번째 슬라이드에만 event listener를 장착하고 이를 제거할 필요가 없음
   - 단, filter 기준이 달라지면 swiper가 다시 생성되기 때문에 event listener를 다시 장착함

**3. EventListener 내부 로직**
- before
  - 감지 빈도가 높은 touchmove event에서 불필요하게 많은 작업을 처리하며 슬라이드 이동 기능을 담당했었음
- after
  - touchstart의 시점에서 내부 스크롤 or 슬라이드 이동 가능성(스크롤이 최상단, 최하단에 위치하는 경우)을 미리 정하고
  - touchmove에서 슬라이드 이동 가능 조건을 만족한 경우에만 내부 스크롤 이동 or 슬라이드 이동을 결정함
  - 실질적으로 두 번의 이벤트(touchstart, 스크롤이 극단에 있을 때의 touchmove)에서만 작업이 처리됨

**4. 가독성**
- Swiper prop 내용을 따로 변수에 담아서 관리
- 2, 3번의 내용을 useEffect 안에서 함수를 정의 및 사용하여 가독성과 성능 측면에서 좋지 않았음
  => 부착되는 리스너 함수를 util 파일에 따로 정의하여 사용

& 불필요해진 기능들에 대한 코드 상당수 제거

### virtual slide 사용에 따른 css 수정 - ffe4a49f953ac7e777e7e23361818b3759a7afd8
 
## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->


## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
