### PR TITLE
#231 작품(text) POST API 연결

### DIFF
--- a/front/src/api/feed/apis/post-feed-api.ts
+++ b/front/src/api/feed/apis/post-feed-api.ts
@@ -1,0 +1,8 @@
+import { axios } from "@/lib/axios";
+import { PostFeedDTO } from "@/api/feed/types";
+
+export const postFeed = async (params: PostFeedDTO) => {
+  return await axios.post("/post", {
+    ...params,
+  });
+};

--- a/front/src/api/feed/hooks/post-feed.ts
+++ b/front/src/api/feed/hooks/post-feed.ts
@@ -1,0 +1,35 @@
+import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+import { getQueryClient, MutationConfig } from "@/lib/react-query";
+import createContentStore from "@/stores/create-content";
+import { postFeed } from "@/api/feed/apis/post-feed-api";
+import { PostFeedDTO } from "@/api/feed/types";
+
+type usePostFeedOptions = {
+  wordId: PostFeedDTO["wordId"];
+  config?: MutationConfig<typeof postFeed>;
+};
+
+export const usePostFeed = ({ wordId }: usePostFeedOptions) => {
+  const router = useRouter();
+  const queryClient = getQueryClient();
+  const invalidateQueryKey = ["wordFeedlist", { wordId }];
+  const { cleanCreateContentState } = createContentStore();
+
+  return useMutation({
+    mutationFn: postFeed,
+    onSuccess: () => {
+      // 현재 작성한 작품까지 fetching할 수 있도록 해당 feedlist 페이지의 query invalidate
+      queryClient.invalidateQueries({
+        queryKey: invalidateQueryKey,
+      });
+      // 작성한 wordId의 feedlist 페이지로 이동
+      router.push(`/feedlist/${wordId}`);
+      // 스토어에 저장된 내용 초기화
+      cleanCreateContentState();
+    },
+    onError: () => {
+      alert("작품 업로드 실패");
+    },
+  });
+};

--- a/front/src/api/feed/hooks/post-feed.ts
+++ b/front/src/api/feed/hooks/post-feed.ts
@@ -24,7 +24,7 @@ export const usePostFeed = ({ wordId }: usePostFeedOptions) => {
         queryKey: invalidateQueryKey,
       });
       // 작성한 wordId의 feedlist 페이지로 이동
-      router.push(`/feedlist/${wordId}`);
+      router.replace(`/feedlist/${wordId}`);
       // 스토어에 저장된 내용 초기화
       cleanCreateContentState();
     },

--- a/front/src/api/feed/types.tsx
+++ b/front/src/api/feed/types.tsx
@@ -8,6 +8,10 @@ export type PostType =
   | "VIDEO"
   | typeof DEFAULT_POST_TYPE;
 
+export type PostAlign = "LEFT" | "CENTER" | "RIGHT";
+
+export type PostVisibility = "PUBLIC" | "PRIVATE";
+
 export type FeedType = "word" | "my" | "bookmark" | "user" | "follow";
 
 export enum FeedTypeEnum {
@@ -54,9 +58,9 @@ export type FeedDetail = {
   postId: number;
   userId: number;
   userName: string;
-  postAlign: "LEFT" | "CENTER" | "RIGHT";
-  postType: "TEXT" | "PAINT" | "MUSIC" | "VIDEO";
-  PostVisibility: "PUBLIC" | "PRIVATE";
+  postAlign: PostAlign;
+  postType: PostType;
+  postVisibility: PostVisibility;
   content: string;
   url: string;
   likedCnt: number;
@@ -102,3 +106,12 @@ export type InfiniteQueriesUpdater<Data> = Updater<
   InfiniteData<Data, unknown> | undefined,
   InfiniteData<Data, unknown> | undefined
 >;
+
+export type PostFeedDTO = {
+  content: string;
+  url: string;
+  wordId: number;
+  postType: PostType;
+  postAlign: PostAlign;
+  postVisibility: PostVisibility;
+};

--- a/front/src/app/create/[word_id]/page.tsx
+++ b/front/src/app/create/[word_id]/page.tsx
@@ -10,7 +10,7 @@ export default function CreateFeed() {
   return (
     <>
       <CreateCategory />
-      {type === "text" ? <PostWrite /> : <PostMedia />}
+      {type === "TEXT" ? <PostWrite /> : <PostMedia />}
     </>
   );
 }

--- a/front/src/app/create/_component/PostMedia/PostMedia.tsx
+++ b/front/src/app/create/_component/PostMedia/PostMedia.tsx
@@ -8,7 +8,7 @@ import AudioPreview from "./AudioPreview/AudioPreview";
 export default function PostMedia() {
   const useContentStore = createContentStore();
   const [preview, sePreview] = useState<string>("");
-  type MediaType = "paint" | "video" | "music";
+  type MediaType = "PAINT" | "MUSIC" | "VIDEO";
   const type = useContentStore.type as MediaType;
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -31,9 +31,9 @@ export default function PostMedia() {
   };
 
   const categories: { [key in MediaType]: string[] } = {
-    paint: ["그림", "image/"],
-    video: ["영상", "video/"],
-    music: ["음악", "audio/"],
+    PAINT: ["그림", "image/"],
+    VIDEO: ["영상", "video/"],
+    MUSIC: ["음악", "audio/"],
   };
 
   useEffect(() => {
@@ -60,9 +60,9 @@ export default function PostMedia() {
           </div>
           <div className={styles["preview-wrapper"]}>
             <div className={styles.media}>
-              {type === "paint" && <Image src={preview} alt="Preview" fill />}
-              {type === "video" && <video controls src={preview}></video>}
-              {type === "music" && <AudioPreview preview={preview} />}
+              {type === "PAINT" && <Image src={preview} alt="Preview" fill />}
+              {type === "VIDEO" && <video controls src={preview}></video>}
+              {type === "MUSIC" && <AudioPreview preview={preview} />}
             </div>
           </div>
         </div>

--- a/front/src/app/create/_component/PostWrite/WriteBody/WriteBody.tsx
+++ b/front/src/app/create/_component/PostWrite/WriteBody/WriteBody.tsx
@@ -1,19 +1,25 @@
 import createContentStore from "@/stores/create-content";
+import { PostAlign } from "@/api/feed/types";
 import styles from "./WriteBody.module.scss";
 
 export default function WriteBody() {
-  const useContentStore = createContentStore();
+  const { textContent, textAlign, setTextContent } = createContentStore();
+  const iconNames: { [key in PostAlign]: string } = {
+    LEFT: "alignLeft",
+    CENTER: "alignCenter",
+    RIGHT: "alignRight",
+  };
 
   const textChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    useContentStore.setTextContent(e.target.value);
+    setTextContent(e.target.value);
   };
 
   return (
     <div className={styles.container}>
       <textarea
-        className={`${styles.textarea} ${styles[useContentStore.textAlign]}`}
+        className={`${styles.textarea} ${styles[iconNames[textAlign]]}`}
         placeholder="여기에 글을 써주세요"
-        value={useContentStore.textContent}
+        value={textContent}
         onChange={textChange}
       />
     </div>

--- a/front/src/app/create/_component/PostWrite/WriteOption/WriteOption.tsx
+++ b/front/src/app/create/_component/PostWrite/WriteOption/WriteOption.tsx
@@ -1,30 +1,28 @@
 import { Icon } from "@/components";
 import styles from "./WriteOption.module.scss";
-import { useState } from "react";
 import createContentStore from "@/stores/create-content";
+import { IconType } from "@/components/Icon/Icon";
+import { PostAlign } from "@/api/feed/types";
 
 export default function WriteOption() {
-  const [textAlign, setTextAlign] = useState<
-    "alignLeft" | "alignCenter" | "alignRight"
-  >("alignLeft");
-  const useContentStore = createContentStore();
-  const setAlign = useContentStore.setTextAlign;
-
+  const { textAlign, textContent, setTextAlign } = createContentStore();
+  const iconNames: { [key in PostAlign]: IconType } = {
+    LEFT: "alignLeft",
+    CENTER: "alignCenter",
+    RIGHT: "alignRight",
+  };
   const copyHandler = () => {};
 
   const textAlignHandler = () => {
     switch (textAlign) {
-      case "alignLeft":
-        setTextAlign("alignCenter");
-        setAlign("alignCenter");
+      case "LEFT":
+        setTextAlign("CENTER");
         break;
-      case "alignCenter":
-        setTextAlign("alignRight");
-        setAlign("alignRight");
+      case "CENTER":
+        setTextAlign("RIGHT");
         break;
-      case "alignRight":
-        setTextAlign("alignLeft");
-        setAlign("alignLeft");
+      case "RIGHT":
+        setTextAlign("LEFT");
         break;
       default:
         break;
@@ -41,9 +39,9 @@ export default function WriteOption() {
         <Icon iconName="copy" />
       </button>
       <button onClick={textAlignHandler}>
-        <Icon iconName={textAlign} />
+        <Icon iconName={iconNames[textAlign]} />
       </button>
-      <div>{useContentStore.textContent.length} 자</div>
+      <div>{textContent.length} 자</div>
       <button onClick={saveHandler}>임시저장</button>
     </footer>
   );

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -11,7 +11,7 @@ import { getWordseed } from "@/api/wordseed";
 export default async function Home() {
   const queryClient = new QueryClient();
   await queryClient.prefetchQuery({
-    queryKey: ["todayWordseed", todaysDate],
+    queryKey: ["wordseed", todaysDate],
     queryFn: () => getWordseed(todaysDate),
   });
 

--- a/front/src/components/Button/create-feed-button.tsx
+++ b/front/src/components/Button/create-feed-button.tsx
@@ -1,10 +1,14 @@
+import Link from "next/link";
+import { useParams } from "next/navigation";
 import Button from "./Button";
 import Icon from "@/components/Icon/Icon";
 
 export default function CreateFeedButton() {
-  const onClick = () => {
-    // create 페이지로 이동
-  };
+  const wordId = useParams().word_id[0];
 
-  return <Button content={<Icon iconName="add" />} onClick={onClick} />;
+  return (
+    <Link href={`/create/${wordId}`}>
+      <Button content={<Icon iconName="add" />} />
+    </Link>
+  );
 }

--- a/front/src/components/Icon/Icon.tsx
+++ b/front/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 
-type IconType =
+export type IconType =
   | "menu"
   | "search"
   | "add"

--- a/front/src/components/Navbar/create-category/create-category.tsx
+++ b/front/src/components/Navbar/create-category/create-category.tsx
@@ -5,13 +5,13 @@ import createContentStore from "@/stores/create-content";
 export default function CreateCategory() {
   const useContentStore = createContentStore();
 
-  type CategoryType = "text" | "paint" | "video" | "music";
+  type CategoryType = "TEXT" | "PAINT" | "MUSIC" | "VIDEO";
 
   const categories: { [key: string]: CategoryType } = {
-    글: "text",
-    그림: "paint",
-    영상: "video",
-    음악: "music",
+    글: "TEXT",
+    그림: "PAINT",
+    영상: "MUSIC",
+    음악: "VIDEO",
   };
 
   const clickHandler = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/front/src/components/feed/feed.tsx
+++ b/front/src/components/feed/feed.tsx
@@ -9,12 +9,7 @@ export default function FeedContent({ feedData }: FeedContentProps) {
   return (
     <div className={style["content-container"]}>
       <div className={style["content-wrapper"]}>
-        <div className={style["content"]}>
-          {
-            "feedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.contentfeedData.content"
-          }
-        </div>
-        {/* <div className={style["content"]}>{feedData.content}</div> */}
+        <div className={style["content"]}>{feedData.content}</div>
       </div>
     </div>
   );

--- a/front/src/components/wordseed-main/wordseed-buttons.tsx
+++ b/front/src/components/wordseed-main/wordseed-buttons.tsx
@@ -4,20 +4,16 @@ import style from "./wordseed.module.scss";
 import Link from "next/link";
 
 type WordseedButtonsProps = {
-  date: string;
-  wordseed: Wordseed | undefined;
+  wordId: Wordseed["wordId"] | undefined;
 };
 
-export default function WordseedButtons({
-  date,
-  wordseed,
-}: WordseedButtonsProps) {
+export default function WordseedButtons({ wordId }: WordseedButtonsProps) {
   return (
     <div className={style["wordseed-buttons"]}>
-      <Link href={`/feedlist/${wordseed?.word}`}>
+      <Link href={`/feedlist/${wordId}`}>
         <Icon iconName="sun" />
       </Link>
-      <Link href={`/create/${date}`}>
+      <Link href={`/create/${wordId}`}>
         <Icon iconName="water" />
       </Link>
     </div>

--- a/front/src/components/wordseed-main/wordseed-main.tsx
+++ b/front/src/components/wordseed-main/wordseed-main.tsx
@@ -5,20 +5,21 @@ import WordseedContainer from "./wordseed-container";
 import WordseedContent from "./wordseed-content";
 import WordseedButtons from "./wordseed-buttons";
 import { getWordseed } from "@/api/wordseed";
+
 type WordseedProps = {
   date: string;
 };
 
 export default function WordseedMain({ date }: WordseedProps) {
-  const { data: wordseed } = useQuery({
-    queryKey: ["todayWordseed", date],
+  const { data: word } = useQuery({
+    queryKey: ["wordseed", date],
     queryFn: () => getWordseed(date),
   });
 
   return (
     <WordseedContainer>
-      <WordseedContent date={date} wordseed={wordseed?.word} />
-      <WordseedButtons date={date} wordseed={wordseed} />
+      <WordseedContent date={date} wordseed={word?.word} />
+      <WordseedButtons wordId={word?.wordId} />
     </WordseedContainer>
   );
 }

--- a/front/src/stores/create-content.ts
+++ b/front/src/stores/create-content.ts
@@ -2,16 +2,17 @@ import { create } from "zustand";
 
 interface CreateContentProps {
   wordseed: string;
-  type: "text" | "paint" | "video" | "music";
-  textAlign: "alignLeft" | "alignCenter" | "alignRight";
+  type: "TEXT" | "PAINT" | "MUSIC" | "VIDEO";
+  textAlign: "LEFT" | "CENTER" | "RIGHT";
   textContent: string;
   file: File | null;
+  postVisibility: "PUBLIC" | "PRIVATE";
 }
 
 interface CreateContentState extends CreateContentProps {
   setWordseed: (wordseed: string) => void;
-  setType: (type: "text" | "paint" | "video" | "music") => void;
-  setTextAlign: (align: "alignLeft" | "alignCenter" | "alignRight") => void;
+  setType: (type: CreateContentProps["type"]) => void;
+  setTextAlign: (align: CreateContentProps["textAlign"]) => void;
   setTextContent: (content: string) => void;
   setFile: (paint: File) => void;
   cleanFile: () => void;
@@ -20,10 +21,11 @@ interface CreateContentState extends CreateContentProps {
 
 const initialState: CreateContentProps = {
   wordseed: "",
-  type: "text",
-  textAlign: "alignLeft",
+  type: "TEXT",
+  textAlign: "LEFT",
   textContent: "",
   file: null,
+  postVisibility: "PUBLIC",
 };
 
 const createContentStore = create<CreateContentState>((set) => ({


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [X] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- 작품(text) POST API 연결

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### postFeed API hook 구현 - 4a47ad1bca75816dacfc1a1fafb3e1a09cbf4aeb
- feedlist query 중 POST한 wordId에 해당하는 query를 최신화하기 위한 invalidate
- 작성한 wordId의 feedlist 페이지로 이동
- create store에 저장된 내용 초기화
### feed 관련 API DTO에 맞게 변수와 type 수정 - 74332a6035619764c1fea414a01d0468673c826b
- type: "TEXT" | "PAINT" | "MUSIC" | "VIDEO" 으로 변경
- textAlign: "LEFT" | "CENTER" | "RIGHT" 으로 변경
- postVisibility: "PUBLIC" | "PRIVATE" 추가
### refactor: create 페이지 params 변경 - 8472215315b5dfb754947bfeb9f2adc699643493
- wordseed(말씨)에서 wordId로 변경
- 위 변경에 따른 Link 주소 변경
### create page navbar에 postFeed API 부착 - c1e63ae3d37e67db555f9365de696a1bbef499ba
- params로 받은 wordId로 query에서 header에 넣을 말씨 추출
- postType이 TEXT일 때, 입력 내용 없이 완료 버튼 누르면 alert 띄움
### 작품 업로드 후 뒤로가기 방지 - 8dfc29f76a820940dc15785d9ed83a71e20095c4
- router.push에서 router.replace로 변경
### 초기 화면에서 말씨 조회 queryKey 변경 - 2f0765963e5fb260e23ac1fe4cbad0919c1a3d52

## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->


## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
