### PR TITLE
#249: 게시글 업로드 요청 성공 시 게시글 리스트 미갱신 문제 해결

### DIFF
--- a/front/src/api/feed/hooks/post-feed.ts
+++ b/front/src/api/feed/hooks/post-feed.ts
@@ -22,6 +22,7 @@ export const usePostFeed = ({ wordId }: usePostFeedOptions) => {
       // 현재 작성한 작품까지 fetching할 수 있도록 해당 feedlist 페이지의 query invalidate
       queryClient.invalidateQueries({
         queryKey: invalidateQueryKey,
+        refetchType: "all",
       });
       // 작성한 wordId의 feedlist 페이지로 이동
       router.replace(`/feedlist/${wordId}`);


### PR DESCRIPTION
## PR 타입
<!-- 하나 이상의 PR 타입을 선택해주세요 -->
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 개요
<!-- PR 작업 내용을 작성해주세요 -->
- 게시글 업로드 이후 게시글 리스트 미갱신 문제 해결

## 변경 사항
<!-- 기존 코드에서 변경된 부분을 설명해주세요 -->
<!-- 커밋 별로 작성하는 것을 권장합니다. -->
### invalidateQueries 수정 - 1e6a9129968bcd2520e5549ba55a389da27f9213
- 게시글 업로드 요청 성공 시 갱신할 queries에 대해 invalidate할 때 refetchType: "all" 속성 추가
- 현재 렌더링 되고 있지 않는 query에 대해서도 refetching 하는 기능

## 테스트 체크리스트
<!-- 완료된 테스트[X]와 예정인 테스트[ ]를 작성해주세요. -->


## 코드 리뷰시 참고 사항
<!-- 리뷰어가 참고할 사항 및 논의할 이슈를 작성해주세요. -->


## 사진 첨부[선택]
<!-- 설명과 함께 사진을 첨부해주세요. -->
